### PR TITLE
Adding Docker support for OpenGRC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,11 @@ EXPOSE 80
 ENV DB_CONNECTION=sqlite \
     DB_HOST=localhost \
     DB_PORT= \
-    DB_DATABASE=/var/www/html/storage/database.sqlite \
+    DB_DATABASE=/var/www/html/storage/opengrc.sqlite \
     DB_USERNAME= \
     DB_PASSWORD=
 
 RUN cp .env.example .env && \
-    echo "DB_CONNECTION=${DB_CONNECTION}" >> .env && \
     echo "DB_CONNECTION=${DB_CONNECTION}" >> .env && \
     echo "DB_HOST=${DB_HOST}" >> .env && \
     echo "DB_PORT=${DB_PORT}" >> .env && \
@@ -33,7 +32,7 @@ RUN cp .env.example .env && \
     echo "DB_PASSWORD=${DB_PASSWORD}" >> .env
 
 RUN git config --global --add safe.directory /var/www/html
-RUN touch /var/www/html/storage/database.sqlite
+RUN touch /var/www/html/storage/opengrc.sqlite
 RUN composer install --no-interaction --optimize-autoloader --no-dev
 RUN php artisan key:generate
 RUN php artisan migrate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:8.3-apache
+
+RUN apt-get update && apt-get install -y git unzip curl sqlite3 libonig-dev libzip-dev libicu-dev
+RUN docker-php-ext-install pdo pdo_mysql bcmath intl zip
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+WORKDIR /var/www/html
+COPY . .
+RUN npm install && npm run build
+RUN mkdir -p /var/www/html/storage/framework/cache/data && mkdir -p /var/www/html/bootstrap/cache
+RUN sed -i 's/Listen 80/Listen 0.0.0.0:80/' /etc/apache2/ports.conf
+RUN sed -i 's|DocumentRoot /var/www/html|DocumentRoot /var/www/html/public|g' /etc/apache2/sites-available/000-default.conf
+EXPOSE 80
+
+ENV DB_CONNECTION=sqlite \
+    DB_HOST=localhost \
+    DB_PORT= \
+    DB_DATABASE=/var/www/html/storage/database.sqlite \
+    DB_USERNAME= \
+    DB_PASSWORD=
+
+RUN cp .env.example .env && \
+    echo "DB_CONNECTION=${DB_CONNECTION}" >> .env && \
+    echo "DB_CONNECTION=${DB_CONNECTION}" >> .env && \
+    echo "DB_HOST=${DB_HOST}" >> .env && \
+    echo "DB_PORT=${DB_PORT}" >> .env && \
+    echo "DB_DATABASE=${DB_DATABASE}" >> .env && \
+    echo "DB_USERNAME=${DB_USERNAME}" >> .env && \
+    echo "DB_PASSWORD=${DB_PASSWORD}" >> .env
+
+RUN git config --global --add safe.directory /var/www/html
+RUN touch /var/www/html/storage/database.sqlite
+RUN composer install --no-interaction --optimize-autoloader --no-dev
+RUN php artisan key:generate
+RUN php artisan migrate
+RUN php artisan db:seed
+ENV APP_ENV=local \
+    APP_DEBUG=false
+RUN echo "APP_ENV=${APP_ENV}" >> .env && \
+    echo "APP_DEBUG=${APP_DEBUG}" >> .env
+RUN php artisan config:clear
+
+RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache && chmod -R 775 /var/www/html/storage /var/www/html/bootstrap/cache
+RUN a2enmod rewrite
+CMD ["apache2-foreground"]

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,7 +22,9 @@ class AppServiceProvider extends ServiceProvider
 
         // Disable mass assignment protection
         Model::unguard();
-        URL::forceScheme('https');
+        if (!$this->app->environment('local')) {
+            URL::forceScheme('https');
+        }
 
         //if table "settings" exists
         if (Schema::hasTable('settings')) {

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,9 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "docker-build": [
+            "docker build -t opengrc ."
         ]
     },
     "extra": {


### PR DESCRIPTION
I added a `Dockerfile` to OpenGRC which uses SQLite persistence and HTTP on port 80 running on Apache. You can set the following environment variables using the `-e <name>=<value>` flag in `docker run`:
- `APP_ENV` - default: local
- `APP_DEBUG` - default: false, set to true to see detailed error screens.
- `DB_CONNECTION` - default: "sqlite", can be set to "mysql" for a MySQL database.
- `DB_HOST` - default: "localhost"
- `DB_PORT` - default: "", can be set to "3306" for a MySQL database.
- `DB_DATABASE` - default: "/var/www/html/storage/opengrc.sqlite", the database name ("opengrc" for MySQL)
- `DB_USERNAME` - default: "", the database user name.
- `DB_PASSWORD` - default: "", the database password.

To run the build, use `composer run-script docker-build`.

Also note that I changed `AppServiceProvider` to force HTTPS if the app environment is not local. This allows the Docker container to run using HTTP and then handle SSL at a different layer of infrastructure. With the addition of a few more environment variables, it also should be possible to allow the container itself to run HTTPS.