### PR TITLE
Added session timeout capability and configuration

### DIFF
--- a/.cursor/rules/opengrc-codebase-rule.mdc
+++ b/.cursor/rules/opengrc-codebase-rule.mdc
@@ -1,0 +1,8 @@
+---
+description: Set the sofware context for all  files in opengrc
+globs: 
+---
+- Application is called OpenGRC
+- OpenGRC is developed using Laravel 11
+- OpenGRC uses Filament 3 on top of Laravel 11
+- UI elements prefer Filament 3 and Livewire

--- a/app/Filament/Pages/Settings/Settings.php
+++ b/app/Filament/Pages/Settings/Settings.php
@@ -124,6 +124,17 @@ class Settings extends BaseSettings
                                 ->maxFiles(1)
                                 ->imagePreviewHeight('150px'),
                         ]),
+                    Tabs\Tab::make('Security')
+                        ->schema([
+                            TextInput::make('security.session_timeout')
+                                ->label('Session Timeout (minutes)')
+                                ->numeric()
+                                ->default(15)
+                                ->minValue(1)
+                                ->maxValue(1440) // Max 24 hours
+                                ->required()
+                                ->helperText('Number of minutes before an inactive session expires. Default: 15 minutes'),
+                        ]),
                 ]),
         ];
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\CheckPasswordReset::class,
+            \App\Http\Middleware\SessionTimeout::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/SessionTimeout.php
+++ b/app/Http/Middleware/SessionTimeout.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+
+class SessionTimeout
+{
+    public function handle(Request $request, Closure $next)
+    {
+
+        $timeout = 15 * 60; // Default timeout in seconds
+        Session::has('last_activity') || Session::put('last_activity', now()->timestamp);
+
+
+        //Ignore non-interactive Livewire requests
+        if (!str_contains($request->path(), 'livewire/update')) {
+            Session::put('last_activity', now()->timestamp);
+        }
+
+        //If session_timeout is set, use it.
+        if (setting('security.session_timeout')) {
+            $timeout = setting('security.session_timeout') * 60;
+        }
+
+        //If the user has been inactive for longer than the timeout, log them out.
+        if (now()->timestamp - Session::get('last_activity', 0) > $timeout) {
+            Auth::logout();
+            Session::flush();
+            return redirect()->route('filament.app.auth.login')->with('error', 'Your session has expired due to inactivity.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -45,6 +45,9 @@ class AppServiceProvider extends ServiceProvider
                         'name' => setting('general.name'),
                     ],
                 ]));
+
+                // Set session lifetime from settings
+                Config::set('session.lifetime', setting('security.session_timeout', 15));
             } else {
                 // if table "settings" does not exist
                 // Error that app was not installed properly

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -72,6 +72,10 @@ class SettingsSeeder extends Seeder
                 'key' => 'mail.templates.evidence_request_body',
                 'value' => '<h1>OpenGRC Evidence Requested</h1><p>Hello, {{ $name }}!</p><p>An auditor has requested evidence from you. Please login to OpenGRC to view the request and provide the necessary evidence.</p><p><strong>URL:</strong> {{ $url }}</p><p>Thank you for your cooperation.</p><p><br></p><p><br></p>',
             ],
+            [
+                'key' => 'security.session_timeout',
+                'value' => '15',
+            ],
         ];
 
         foreach ($settings as $setting) {


### PR DESCRIPTION
- Added SessionTimeout middleware to automatically log out inactive users
- Added session timeout configuration to settings page
- Default timeout is 15 minutes if not configured
- Session timeout can be configured in security settings