### PR TITLE
feat(i18n): add multi-language support for en, es, fr, hr locales

### DIFF
--- a/app/Enums/Applicability.php
+++ b/app/Enums/Applicability.php
@@ -5,18 +5,18 @@ namespace App\Enums;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
-enum Applicability: string implements hasColor, hasLabel
+enum Applicability: string implements HasColor, HasLabel
 {
     case APPLICABLE = 'Applicable';
     case NOTAPPLICABLE = 'Not Applicable';
-    case UNKNOWN = 'Unknown';
+    case PARTIALLYAPPLICABLE = 'Partially Applicable';
 
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::APPLICABLE => 'Applicable',
-            self::NOTAPPLICABLE => 'Not Applicable',
-            self::UNKNOWN => 'Not Assessed',
+            self::APPLICABLE => __('enums.applicability.applicable'),
+            self::NOTAPPLICABLE => __('enums.applicability.not_applicable'),
+            self::PARTIALLYAPPLICABLE => __('enums.applicability.partially_applicable'),
         };
     }
 
@@ -24,8 +24,8 @@ enum Applicability: string implements hasColor, hasLabel
     {
         return match ($this) {
             self::APPLICABLE => 'success',
-            self::NOTAPPLICABLE => 'primary',
-            self::UNKNOWN => 'warning',
+            self::NOTAPPLICABLE => 'danger',
+            self::PARTIALLYAPPLICABLE => 'warning',
         };
     }
 }

--- a/app/Enums/ControlCategory.php
+++ b/app/Enums/ControlCategory.php
@@ -5,9 +5,9 @@ namespace App\Enums;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
-enum ControlCategory: string implements hasColor, hasLabel
+enum ControlCategory: string implements HasColor, HasLabel
 {
-    case PREVENTATIVE = 'Preventative';
+    case PREVENTIVE = 'Preventive';
     case DETECTIVE = 'Detective';
     case CORRECTIVE = 'Corrective';
     case DETERRENT = 'Deterrent';
@@ -19,24 +19,24 @@ enum ControlCategory: string implements hasColor, hasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::PREVENTATIVE => 'Preventative',
-            self::DETECTIVE => 'Detective',
-            self::CORRECTIVE => 'Corrective',
-            self::DETERRENT => 'Deterrent',
-            self::COMPENSATING => 'Compensating',
-            self::RECOVERY => 'Recovery',
-            self::OTHER => 'Other',
-            self::UNKNOWN => 'Unknown',
+            self::PREVENTIVE => __('enums.control_category.preventive'),
+            self::DETECTIVE => __('enums.control_category.detective'),
+            self::CORRECTIVE => __('enums.control_category.corrective'),
+            self::DETERRENT => __('enums.control_category.deterrent'),
+            self::COMPENSATING => __('enums.control_category.compensating'),
+            self::RECOVERY => __('enums.control_category.recovery'),
+            self::OTHER => __('enums.control_category.other'),
+            self::UNKNOWN => __('enums.control_category.unknown'),
         };
     }
 
     public function getColor(): string|array|null
     {
         return match ($this) {
-            self::PREVENTATIVE => 'primary',
-            self::DETECTIVE => 'primary',
-            self::CORRECTIVE => 'primary',
-            self::DETERRENT => 'primary',
+            self::PREVENTIVE => 'success',
+            self::DETECTIVE => 'warning',
+            self::CORRECTIVE => 'danger',
+            self::DETERRENT => 'info',
             self::COMPENSATING => 'primary',
             self::RECOVERY => 'primary',
             self::OTHER => 'primary',

--- a/app/Enums/ControlEnforcementCategory.php
+++ b/app/Enums/ControlEnforcementCategory.php
@@ -15,10 +15,10 @@ enum ControlEnforcementCategory: string implements hasColor, hasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::MANDATORY => 'Mandatory',
-            self::ADDRESSABLE => 'Addressable',
-            self::OPTIONAL => 'Optional',
-            self::OTHER => 'Other',
+            self::MANDATORY => __('enums.control_enforcement_category.mandatory'),
+            self::ADDRESSABLE => __('enums.control_enforcement_category.addressable'),
+            self::OPTIONAL => __('enums.control_enforcement_category.optional'),
+            self::OTHER => __('enums.control_enforcement_category.other'),
         };
     }
 
@@ -28,8 +28,7 @@ enum ControlEnforcementCategory: string implements hasColor, hasLabel
             self::MANDATORY => 'danger',
             self::ADDRESSABLE => 'warning',
             self::OPTIONAL => 'primary',
-            self::OTHER => 'primary',
-            self::UNKNOWN => 'primary',
+            self::OTHER => 'primary'
         };
     }
 

--- a/app/Enums/ControlType.php
+++ b/app/Enums/ControlType.php
@@ -16,11 +16,11 @@ enum ControlType: string implements hasColor, hasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::ADMINISTRATIVE => 'Administrative',
-            self::TECHNICAL => 'Technical',
-            self::PHYSICAL => 'Physical',
-            self::OPERATIONAL => 'Operational',
-            self::OTHER => 'Other',
+            self::ADMINISTRATIVE => __('enums.control_type.administrative'),
+            self::TECHNICAL => __('enums.control_type.technical'),
+            self::PHYSICAL => __('enums.control_type.physical'),
+            self::OPERATIONAL => __('enums.control_type.operational'),
+            self::OTHER => __('enums.control_type.other'),
         };
     }
 

--- a/app/Enums/Effectiveness.php
+++ b/app/Enums/Effectiveness.php
@@ -5,7 +5,7 @@ namespace App\Enums;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
-enum Effectiveness: string implements hasColor, hasLabel
+enum Effectiveness: string implements HasColor, HasLabel
 {
     case EFFECTIVE = 'Effective';
     case PARTIAL = 'Partially Effective';
@@ -15,10 +15,10 @@ enum Effectiveness: string implements hasColor, hasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::EFFECTIVE => 'Effective',
-            self::PARTIAL => 'Partially Effective',
-            self::INEFFECTIVE => 'Not Effective',
-            self::UNKNOWN => 'Not Assessed',
+            self::EFFECTIVE => __('enums.effectiveness.effective'),
+            self::PARTIAL => __('enums.effectiveness.partial'),
+            self::INEFFECTIVE => __('enums.effectiveness.ineffective'),
+            self::UNKNOWN => __('enums.effectiveness.unknown'),
         };
     }
 
@@ -28,7 +28,7 @@ enum Effectiveness: string implements hasColor, hasLabel
             self::EFFECTIVE => 'success',
             self::PARTIAL => 'warning',
             self::INEFFECTIVE => 'danger',
-            self::UNKNOWN => 'primary',
+            self::UNKNOWN => 'gray',
         };
     }
 }

--- a/app/Enums/WorkflowStatus.php
+++ b/app/Enums/WorkflowStatus.php
@@ -15,10 +15,10 @@ enum WorkflowStatus: string implements hasColor, hasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::NOTSTARTED => 'Not Started',
-            self::INPROGRESS => 'In Progress',
-            self::COMPLETED => 'Completed',
-            self::UNKNOWN => 'Unknown',
+            self::NOTSTARTED => __('enums.workflow_status.not_started'),
+            self::INPROGRESS => __('enums.workflow_status.in_progress'),
+            self::COMPLETED => __('enums.workflow_status.completed'),
+            self::UNKNOWN => __('enums.workflow_status.unknown'),
         };
     }
 

--- a/app/Filament/Resources/AuditResource.php
+++ b/app/Filament/Resources/AuditResource.php
@@ -38,12 +38,12 @@ class AuditResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return __('navigation.resources.audit');
+        return __('audit.navigation.label');
     }
 
     public static function getNavigationGroup(): string
     {
-        return __('navigation.groups.foundations');
+        return __('audit.navigation.group');
     }
 
     public static function form(Form $form): Form
@@ -54,35 +54,42 @@ class AuditResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
-            ->emptyStateHeading('No Audits Created')
-            ->emptyStateDescription('Try creating a new audit by clicking the "Create an Audit" button above to get started!')
+            ->emptyStateHeading(__('audit.table.empty_state.heading'))
+            ->emptyStateDescription(__('audit.table.empty_state.description'))
             ->columns([
                 Tables\Columns\TextColumn::make('title')
+                    ->label(__('audit.table.columns.title'))
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('audit_type')
+                    ->label(__('audit.table.columns.audit_type'))
                     ->sortable()
                     ->formatStateUsing(fn ($state) => ucfirst($state))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('status')
+                    ->label(__('audit.table.columns.status'))
                     ->sortable()
                     ->badge()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('manager.name')
-                    ->label('Manager')
+                    ->label(__('audit.table.columns.manager'))
                     ->default('Unassigned')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('start_date')
+                    ->label(__('audit.table.columns.start_date'))
                     ->date()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('end_date')
+                    ->label(__('audit.table.columns.end_date'))
                     ->date()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('audit.table.columns.created_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('audit.table.columns.updated_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -116,15 +123,20 @@ class AuditResource extends Resource
     {
         return $infolist
             ->schema([
-                Section::make('Audit Details')
+                Section::make(__('audit.infolist.section.title'))
                     ->columns(3)
                     ->schema([
-                        TextEntry::make('title'),
+                        TextEntry::make('title')
+                            ->label(__('audit.table.columns.title')),
                         TextEntry::make('status')
+                            ->label(__('audit.table.columns.status'))
                             ->badge(),
-                        TextEntry::make('manager.name'),
-                        TextEntry::make('start_date'),
-                        TextEntry::make('end_date'),
+                        TextEntry::make('manager.name')
+                            ->label(__('audit.table.columns.manager')),
+                        TextEntry::make('start_date')
+                            ->label(__('audit.table.columns.start_date')),
+                        TextEntry::make('end_date')
+                            ->label(__('audit.table.columns.end_date')),
                         TextEntry::make('description')
                             ->columnSpanFull()
                             ->html(),

--- a/app/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -15,7 +15,7 @@ class ListAudits extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label('Create an Audit'),
+                ->label(__('audit.actions.create')),
         ];
     }
 

--- a/app/Filament/Resources/ControlResource.php
+++ b/app/Filament/Resources/ControlResource.php
@@ -41,12 +41,22 @@ class ControlResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return __('navigation.resources.control');
+        return __('control.navigation.label');
     }
 
     public static function getNavigationGroup(): string
     {
-        return __('navigation.groups.foundations');
+        return __('control.navigation.group');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('control.model.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('control.model.plural_label');
     }
 
     protected static ?string $recordTitleAttribute = 'title';
@@ -58,7 +68,7 @@ class ControlResource extends Resource
             ->schema([
                 Forms\Components\TextInput::make('code')
                     ->required()
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter a unique code for this control. This code will be used to identify this control in the system.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.code.tooltip'))
                     ->maxLength(255)
                     ->unique(Control::class, 'code', ignoreRecord: true)
                     ->live()
@@ -66,31 +76,31 @@ class ControlResource extends Resource
                         $livewire->validateOnly($component->getStatePath());
                     }),
                 Forms\Components\Select::make('standard_id')
-                    ->label('Standard')
+                    ->label(__('control.form.standard.label'))
                     ->searchable()
                     ->options(Standard::pluck('name', 'id')->toArray())
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'All controls must belong to a standard. If you dont have a standard to relate this control to, consider creating a new one first.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.standard.tooltip'))
                     ->required(),
                 Forms\Components\Select::make('enforcement')
                     ->options(ControlEnforcementCategory::class)
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select an enforcement category for this control. This will help determine how this control is enforced.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.enforcement.tooltip'))
                     ->required(),
                 Forms\Components\TextInput::make('title')
                     ->required()
                     ->columnSpanFull()
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter a title for this control.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.title.tooltip'))
                     ->maxLength(1024),
                 TinyEditor::make('description')
                     ->required()
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter a description for this control. This should describe, in detail, the requirements for this this control.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.description.tooltip'))
                     ->extraInputAttributes(['class' => 'filament-forms-rich-editor-unfiltered'])
                     ->columnSpanFull(),
                 TinyEditor::make('discussion')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Optional: Provide any context or additional information about this control that would help someone determine how to implement it.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.discussion.tooltip'))
                     ->columnSpanFull(),
                 TinyEditor::make('test')
-                    ->label('Test Plan')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Optional: How do you plan to test that this control is in place and effective?')
+                    ->label(__('control.form.test.label'))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('control.form.test.tooltip'))
                     ->columnSpanFull(),
             ]);
     }
@@ -105,60 +115,62 @@ class ControlResource extends Resource
             {
                 public function toHtml()
                 {
-                    return "<div class='fi-section-content p-6'>
-                        Controls are the 'how' of security implementation - they are the specific mechanisms, policies, procedures, 
-                        and tools used to enforce standards and protect assets. Controls can be technical (like firewalls or 
-                        encryption), administrative (like policies or training), or physical (like security cameras or door locks). 
-                        Each control should be designed to address specific risks and meet particular security requirements defined 
-                        by standards. For instance, to meet a standard requiring secure data transmission, a control might specify 
-                        the use of TLS 1.2 or higher for all external communications. Controls are the practical manifestation of 
-                        security standards and form the backbone of an organization's security infrastructure.
-                        </div>";
+                    return "<div class='fi-section-content p-6'>" . 
+                        __('control.table.description') . 
+                        "</div>";
                 }
             })
-            ->emptyStateHeading('No Controls Added Yet')
-            ->emptyStateDescription(new HtmlString("There are no controls to display. Try adding new controls to your existing 
-            standards. You can also import standards and controls with using <a class='text-blue-500' href='".route('filament.app.resources.bundles.index')."'>Content Bundles</a>."))
+            ->emptyStateHeading(__('control.table.empty_state.heading'))
+            ->emptyStateDescription(new HtmlString(__('control.table.empty_state.description', [
+                'url' => route('filament.app.resources.bundles.index')
+            ])))
             ->columns([
                 Tables\Columns\TextColumn::make('code')
+                    ->label(__('control.table.columns.code'))
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('title')
+                    ->label(__('control.table.columns.title'))
                     ->sortable()
                     ->searchable()
                     ->wrap(),
                 Tables\Columns\TextColumn::make('standard.name')
-                    ->label('Standard')
+                    ->label(__('control.table.columns.standard'))
                     ->wrap()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('type')
+                    ->label(__('control.table.columns.type'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('category')
+                    ->label(__('control.table.columns.category'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('enforcement')
+                    ->label(__('control.table.columns.enforcement'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('LatestAuditEffectiveness')
-                    ->label('Effectiveness')
+                    ->label(__('control.table.columns.effectiveness'))
                     ->badge()
                     ->sortable()
                     ->default(function (Control $record) {
                         return $record->getEffectiveness();
                     }),
                 Tables\Columns\TextColumn::make('applicability')
-                    ->label('Applicability')
+                    ->label(__('control.table.columns.applicability'))
                     ->sortable()
                     ->badge(),
                 Tables\Columns\TextColumn::make('LatestAuditDate')
-                    ->label('Assessed')
+                    ->label(__('control.table.columns.assessed'))
                     ->sortable()
                     ->default(function (Control $record) {
                         return $record->getEffectivenessDate();
                     }),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('control.table.columns.created_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('control.table.columns.updated_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
@@ -167,22 +179,22 @@ class ControlResource extends Resource
                 Tables\Filters\SelectFilter::make('standard_id')
                     ->options(Standard::pluck('name', 'id')->toArray())
                     ->multiple()
-                    ->label('Standard'),
+                    ->label(__('control.table.filters.standard')),
                 Tables\Filters\SelectFilter::make('effectiveness')
                     ->options(Effectiveness::class)
-                    ->label('Effectiveness'),
+                    ->label(__('control.table.filters.effectiveness')),
                 Tables\Filters\SelectFilter::make('type')
                     ->options(ControlType::class)
-                    ->label('Type'),
+                    ->label(__('control.table.filters.type')),
                 Tables\Filters\SelectFilter::make('category')
                     ->options(ControlCategory::class)
-                    ->label('Category'),
+                    ->label(__('control.table.filters.category')),
                 Tables\Filters\SelectFilter::make('enforcement')
                     ->options(ControlEnforcementCategory::class)
-                    ->label('Enforcement'),
+                    ->label(__('control.table.filters.enforcement')),
                 Tables\Filters\SelectFilter::make('applicability')
                     ->options(Applicability::class)
-                    ->label('Applicability'),
+                    ->label(__('control.table.filters.applicability')),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
@@ -223,7 +235,7 @@ class ControlResource extends Resource
     {
         return $infolist
             ->schema([
-                Section::make('Control Details')
+                Section::make(__('control.infolist.section_title'))
                     ->columns(3)
                     ->schema([
                         TextEntry::make('title')->columnSpanFull(),
@@ -248,7 +260,7 @@ class ControlResource extends Resource
                             ->hidden(fn (Control $record) => ! $record->discussion)
                             ->html(),
                         TextEntry::make('test')
-                            ->label('Test Plan')
+                            ->label(__('control.infolist.test_plan'))
                             ->columnSpanFull()
                             ->hidden(fn (Control $record) => ! $record->discussion)
                             ->html(),

--- a/app/Filament/Resources/ImplementationResource.php
+++ b/app/Filament/Resources/ImplementationResource.php
@@ -39,12 +39,12 @@ class ImplementationResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return __('navigation.resources.implementation');
+        return __('implementation.navigation.label');
     }
 
     public static function getNavigationGroup(): string
     {
-        return __('navigation.groups.foundations');
+        return __('implementation.navigation.group');
     }
 
     public static function form(Form $form): Form
@@ -111,47 +111,46 @@ class ImplementationResource extends Resource
             {
                 public function toHtml()
                 {
-                    return "<div class='fi-section-content p-6'>
-                        Implementations represent the actual deployment and operation of security controls within an organization. 
-                        They are the specific instances of how controls are put into practice, including the tools, configurations, 
-                        processes, and procedures used. Each implementation should be documented with sufficient detail to understand 
-                        how the control is operating, who is responsible for maintaining it, and how its effectiveness can be verified. 
-                        For example, while a control might specify the need for access reviews, an implementation would detail the 
-                        exact process, including which tool is used, who conducts the reviews, how often they occur, and what 
-                        documentation is maintained. Implementations bridge the gap between theoretical security controls and their 
-                        practical application in the organization.
-                        </div>";
+                    return "<div class='fi-section-content p-6'>" . 
+                        __('implementation.table.description') . 
+                        "</div>";
                 }
             })
-            ->emptyStateHeading('No implementations found')
-            ->emptyStateDescription('Try creating a new implementation by clicking the "Create Implementation" button above.')
+            ->emptyStateHeading(__('implementation.table.empty_state.heading'))
+            ->emptyStateDescription(__('implementation.table.empty_state.description'))
             ->columns([
                 Tables\Columns\TextColumn::make('code')
+                    ->label(__('implementation.table.columns.code'))
                     ->toggleable()
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('title')
+                    ->label(__('implementation.table.columns.title'))
                     ->toggleable()
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('effectiveness')
+                    ->label(__('implementation.table.columns.effectiveness'))
                     ->getStateUsing(fn ($record) => $record->getEffectiveness())
                     ->sortable()
                     ->badge(),
                 Tables\Columns\TextColumn::make('last_assessed')
-                    ->label('Last Audit')
+                    ->label(__('implementation.table.columns.last_assessed'))
                     ->getStateUsing(fn ($record) => $record->getEffectivenessDate() ? $record->getEffectivenessDate() : 'Not yet audited')
                     ->sortable()
                     ->badge(),
                 Tables\Columns\TextColumn::make('status')
+                    ->label(__('implementation.table.columns.status'))
                     ->toggleable()
                     ->sortable()
                     ->searchable(),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('implementation.table.columns.created_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('implementation.table.columns.updated_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Resources/ImplementationResource/Pages/ListImplementations.php
+++ b/app/Filament/Resources/ImplementationResource/Pages/ListImplementations.php
@@ -14,7 +14,7 @@ class ListImplementations extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->label('Create Implementation'),
+                ->label(__('implementation.actions.create')),
         ];
     }
 }

--- a/app/Filament/Resources/ProgramResource.php
+++ b/app/Filament/Resources/ProgramResource.php
@@ -31,28 +31,41 @@ class ProgramResource extends Resource
         return __('navigation.groups.foundations');
     }
 
+    public static function getModelLabel(): string
+    {
+        return __('programs.labels.singular');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('programs.labels.plural');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
+                    ->label(__('programs.form.name'))
                     ->columnSpanFull()
                     ->required()
                     ->maxLength(255),
                 Forms\Components\Textarea::make('description')
+                    ->label(__('programs.form.description'))
                     ->maxLength(65535)
                     ->columnSpanFull(),
                 Forms\Components\Select::make('program_manager_id')
-                    ->label('Program Manager')
+                    ->label(__('programs.form.program_manager'))
                     ->relationship('programManager', 'name')
                     ->searchable()
                     ->preload()
                     ->required(),
                 Forms\Components\Select::make('scope_status')
+                    ->label(__('programs.form.scope_status'))
                     ->options([
-                        'In Scope' => 'In Scope',
-                        'Out of Scope' => 'Out of Scope',
-                        'Pending Review' => 'Pending Review',
+                        'In Scope' => __('programs.scope_status.in_scope'),
+                        'Out of Scope' => __('programs.scope_status.out_of_scope'),
+                        'Pending Review' => __('programs.scope_status.pending_review'),
                     ])
                     ->required(),
             ]);
@@ -65,35 +78,30 @@ class ProgramResource extends Resource
             {
                 public function toHtml()
                 {
-                    return "<div class='fi-section-content p-6'>
-                        Programs serve as comprehensive frameworks that unite security standards and controls into cohesive, manageable
-                        initiatives within an organization. They represent structured approaches to achieving specific security objectives
-                        by combining relevant standards (which define 'what' needs to be done) with appropriate controls (which specify
-                        'how' to do it). Each program typically addresses a distinct area of compliance, risk management, or security
-                        enhancement, making it easier to track progress, measure effectiveness, and ensure accountability. For example,
-                        a Data Privacy Program might incorporate standards from GDPR and CCPA, implementing specific controls like
-                        data encryption, access management, and regular audits to meet these requirements. By organizing security
-                        measures into programs, organizations can better coordinate their security efforts, allocate resources
-                        effectively, and maintain clear oversight of their security posture across different domains and objectives.
-                        </div>";
+                    return "<div class='fi-section-content p-6'>" . __('programs.description') . "</div>";
                 }
             })
             ->columns([
                 Tables\Columns\TextColumn::make('name')
+                    ->label(__('programs.table.name'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('programManager.name')
-                    ->label('Program Manager')
+                    ->label(__('programs.table.program_manager'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('last_audit_date')
+                    ->label(__('programs.table.last_audit_date'))
                     ->date()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('scope_status')
+                    ->label(__('programs.table.scope_status'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('programs.table.created_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('programs.table.updated_at'))
                     ->dateTime()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),

--- a/app/Filament/Resources/ProgramResource/Pages/ListPrograms.php
+++ b/app/Filament/Resources/ProgramResource/Pages/ListPrograms.php
@@ -10,6 +10,11 @@ class ListPrograms extends ListRecords
 {
     protected static string $resource = ProgramResource::class;
 
+    public function getHeading(): string
+    {
+        return __('programs.heading');
+    }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Resources/StandardResource.php
+++ b/app/Filament/Resources/StandardResource.php
@@ -37,12 +37,22 @@ class StandardResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return __('navigation.resources.standard');
+        return __('standard.navigation.label');
     }
 
     public static function getNavigationGroup(): string
     {
-        return __('navigation.groups.foundations');
+        return __('standard.navigation.group');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('standard.model.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('standard.model.plural_label');
     }
 
     public static function form(Form $form): Form
@@ -55,14 +65,14 @@ class StandardResource extends Resource
                     ->columnSpanFull()
                     ->required()
                     ->maxLength(255)
-                    ->placeholder('e.g. Critical Security Controls, Version 8')
-                    ->hint('Enter the name of the standard.')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Need some more information?'),
+                    ->placeholder(__('standard.form.name.placeholder'))
+                    ->hint(__('standard.form.name.hint'))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('standard.form.name.tooltip')),
                 TextInput::make('code')
                     ->required()
                     ->maxLength(255)
-                    ->placeholder('e.g. CSCv8')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Give the standard a unique ID or Code.')
+                    ->placeholder(__('standard.form.code.placeholder'))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('standard.form.code.tooltip'))
                     ->unique(Standard::class, 'code', ignoreRecord: true)
                     ->live()
                     ->afterStateUpdated(function ($livewire, $component) {
@@ -71,27 +81,27 @@ class StandardResource extends Resource
                 TextInput::make('authority')
                     ->required()
                     ->maxLength(255)
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter the name of the organization that maintains the standard.')
-                    ->placeholder('e.g. Center for Internet Security'),
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('standard.form.authority.tooltip'))
+                    ->placeholder(__('standard.form.authority.placeholder')),
                 Select::make('status')
                     ->default(StandardStatus::DRAFT)
                     ->required()
                     ->enum(StandardStatus::class)
                     ->options(StandardStatus::class)
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Select the relevance of this standard to your organization.')
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('standard.form.status.tooltip'))
                     ->native(false),
                 TextInput::make('reference_url')
                     ->columnSpanFull()
                     ->maxLength(255)
                     ->url()
-                    ->placeholder('e.g. https://www.cisecurity.org/controls/')
-                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: 'Enter the URL of the official standard document.'),
+                    ->placeholder(__('standard.form.reference_url.placeholder'))
+                    ->hintIcon('heroicon-m-question-mark-circle', tooltip: __('standard.form.reference_url.tooltip')),
                 RichEditor::make('description')
                     ->columnSpanFull()
                     ->maxLength(65535)
                     ->required()
-                    ->hint('Describe the purpose and scope of the standard.')
-                    ->placeholder('Description'),
+                    ->hint(__('standard.form.description.hint'))
+                    ->placeholder(__('standard.form.description.placeholder')),
             ]);
     }
 
@@ -105,73 +115,65 @@ class StandardResource extends Resource
             {
                 public function toHtml()
                 {
-                    return "<div class='fi-section-content p-6'>
-                        Standards define the 'what' in security and compliance by establishing specific requirements, guidelines, 
-                        or best practices that need to be followed. They serve as benchmarks against which an organization's 
-                        security posture can be measured. Standards can originate from various sources, including regulatory 
-                        bodies (like HIPAA or GDPR), industry frameworks (such as ISO 27001 or NIST), or internal organizational 
-                        policies. Each standard typically outlines specific criteria that must be met to achieve compliance or 
-                        maintain security. For example, a password standard might specify minimum length requirements, complexity 
-                        rules, and expiration periods. Standards provide the foundation for controls, which then implement these 
-                        requirements in practical ways.
-                        </div>";
+                    return "<div class='fi-section-content p-6'>" . 
+                        __('standard.table.description') . 
+                        "</div>";
                 }
             })
             ->columns([
                 Tables\Columns\TextColumn::make('code')
+                    ->label(__('standard.table.columns.code'))
                     ->searchable()
                     ->sortable(),
                 Tables\Columns\TextColumn::make('name')
+                    ->label(__('standard.table.columns.name'))
                     ->searchable()
                     ->sortable()
                     ->wrap(true),
                 Tables\Columns\TextColumn::make('description')
+                    ->label(__('standard.table.columns.description'))
                     ->html()
                     ->searchable()
                     ->sortable()
                     ->wrap(true)
                     ->limit(250),
                 Tables\Columns\TextColumn::make('authority')
+                    ->label(__('standard.table.columns.authority'))
                     ->searchable()
                     ->sortable()
                     ->wrap(true),
                 Tables\Columns\TextColumn::make('status')
+                    ->label(__('standard.table.columns.status'))
                     ->badge()
                     ->sortable(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
                     ->options(StandardStatus::class)
-                    ->label('Status'),
+                    ->label(__('standard.table.filters.status')),
                 Tables\Filters\SelectFilter::make('authority')
                     ->options(Standard::pluck('authority', 'authority')->toArray())
-                    ->label('Authority'),
+                    ->label(__('standard.table.filters.authority')),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()->hiddenLabel(),
                 Tables\Actions\ActionGroup::make([
                     Tables\Actions\Action::make('set_in_scope')
-                        ->label('Set In Scope')
+                        ->label(__('standard.table.actions.set_in_scope.label'))
                         ->icon('heroicon-o-check-circle')
-                        ->modalHeading('Set Standard In Scope')
-                        ->modalContent(new HtmlString('Setting a Standard as "in-scope" will allow you to track and 
-                        audit to this standard. However, it will also show up in your dashboards and metrics. You can 
-                        undo this action with minimal disruption.<br><br>
-                        Are you sure you want to set this standard in scope?'))
-                        ->modalSubmitActionLabel('Set In Scope')
+                        ->modalHeading(__('standard.table.actions.set_in_scope.modal_heading'))
+                        ->modalContent(new HtmlString(__('standard.table.actions.set_in_scope.modal_content')))
+                        ->modalSubmitActionLabel(__('standard.table.actions.set_in_scope.submit_label'))
                         ->hidden(
                             fn ($record) => $record->status === StandardStatus::IN_SCOPE
                         )
                         ->action(fn ($record) => $record->update(['status' => StandardStatus::IN_SCOPE])),
                     Tables\Actions\Action::make('set_out_scope')
-                        ->label('Remove from Scope')
+                        ->label(__('standard.table.actions.set_out_scope.label'))
                         ->icon('heroicon-o-check-circle')
-                        ->modalHeading('Remove from Scope')
-                        ->modalContent(new HtmlString('If you remove this standard from scope, it will no longer
-                        appear in your dashboards and metrics. You will also not be able to audit the standard until 
-                        you set it back in-scope. No data will be modified as a result - this can be undone.<br><br>
-                        Are you sure you want to set this standard in scope?'))
-                        ->modalSubmitActionLabel('Remove from Scope')
+                        ->modalHeading(__('standard.table.actions.set_out_scope.modal_heading'))
+                        ->modalContent(new HtmlString(__('standard.table.actions.set_out_scope.modal_content')))
+                        ->modalSubmitActionLabel(__('standard.table.actions.set_out_scope.submit_label'))
                         ->hidden(
                             fn ($record) => $record->status !== StandardStatus::IN_SCOPE
                         )
@@ -179,7 +181,7 @@ class StandardResource extends Resource
                     Tables\Actions\EditAction::make(),
                     Tables\Actions\DeleteAction::make(),
                     Tables\Actions\RestoreAction::make(),
-                ])->label('Actions'),
+                ])->label(__('standard.table.actions.group_label')),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
@@ -188,11 +190,12 @@ class StandardResource extends Resource
                     Tables\Actions\RestoreBulkAction::make(),
                 ]),
             ])
-            ->emptyStateHeading(new HtmlString('No Standards Found'))
+            ->emptyStateHeading(new HtmlString(__('standard.table.empty_state.heading')))
             ->emptyStateDescription(
-                new HtmlString("Try creating a new standard or adding one from an <a style='text-decoration: underline' href='"
-                .route('filament.app.resources.bundles.index').
-                "'>OpenGRC Bundle</a>"));
+                new HtmlString(__('standard.table.empty_state.description', [
+                    'url' => route('filament.app.resources.bundles.index')
+                ]))
+            );
     }
 
     public static function getRelations(): array
@@ -226,7 +229,7 @@ class StandardResource extends Resource
     {
         return $infolist
             ->schema([
-                Section::make('Standard Details')
+                Section::make(__('standard.infolist.section_title'))
                     ->columns(4)
                     ->schema([
                         TextEntry::make('name'),

--- a/app/Filament/Widgets/AuditListWidget.php
+++ b/app/Filament/Widgets/AuditListWidget.php
@@ -18,6 +18,7 @@ class AuditListWidget extends BaseWidget
             ->query(
                 Audit::query()->latest('updated_at')->take(5)
             )
+            ->heading(trans('widgets.audit_list.heading'))
             ->emptyStateHeading(new HtmlString(trans('widgets.audit_list.empty_heading')))
             ->emptyStateDescription(trans('widgets.audit_list.empty_description'))
             ->emptyStateIcon('heroicon-o-check-circle')

--- a/composer.lock
+++ b/composer.lock
@@ -4844,16 +4844,16 @@
         },
         {
             "name": "openspout/openspout",
-            "version": "v4.29.1",
+            "version": "v4.28.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openspout/openspout.git",
-                "reference": "ec83106bc3922fe94c9d37976ba6b7259511c4c5"
+                "reference": "ab05a09fe6fce57c90338f83280648a9786ce36b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openspout/openspout/zipball/ec83106bc3922fe94c9d37976ba6b7259511c4c5",
-                "reference": "ec83106bc3922fe94c9d37976ba6b7259511c4c5",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/ab05a09fe6fce57c90338f83280648a9786ce36b",
+                "reference": "ab05a09fe6fce57c90338f83280648a9786ce36b",
                 "shasum": ""
             },
             "require": {
@@ -4863,17 +4863,17 @@
                 "ext-libxml": "*",
                 "ext-xmlreader": "*",
                 "ext-zip": "*",
-                "php": "~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
                 "ext-zlib": "*",
-                "friendsofphp/php-cs-fixer": "^3.71.0",
-                "infection/infection": "^0.29.14",
+                "friendsofphp/php-cs-fixer": "^3.68.3",
+                "infection/infection": "^0.29.10",
                 "phpbench/phpbench": "^1.4.0",
-                "phpstan/phpstan": "^2.1.8",
+                "phpstan/phpstan": "^2.1.2",
                 "phpstan/phpstan-phpunit": "^2.0.4",
-                "phpstan/phpstan-strict-rules": "^2.0.3",
-                "phpunit/phpunit": "^12.0.7"
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^11.5.4"
             },
             "suggest": {
                 "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
@@ -4921,7 +4921,7 @@
             ],
             "support": {
                 "issues": "https://github.com/openspout/openspout/issues",
-                "source": "https://github.com/openspout/openspout/tree/v4.29.1"
+                "source": "https://github.com/openspout/openspout/tree/v4.28.5"
             },
             "funding": [
                 {
@@ -4933,7 +4933,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T14:40:46+00:00"
+            "time": "2025-01-30T13:51:11+00:00"
         },
         {
             "name": "outerweb/filament-settings",
@@ -6678,16 +6678,16 @@
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.92.3",
+            "version": "1.92.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "45001525ccbb3804edb46a3410157f40de2ddd89"
+                "reference": "d20b1969f836d210459b78683d85c9cd5c5f508c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/45001525ccbb3804edb46a3410157f40de2ddd89",
-                "reference": "45001525ccbb3804edb46a3410157f40de2ddd89",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/d20b1969f836d210459b78683d85c9cd5c5f508c",
+                "reference": "d20b1969f836d210459b78683d85c9cd5c5f508c",
                 "shasum": ""
             },
             "require": {
@@ -6698,6 +6698,7 @@
                 "mockery/mockery": "^1.5",
                 "orchestra/testbench": "^7.7|^8.0|^9.0|^10.0",
                 "pestphp/pest": "^1.23|^2.1|^3.1",
+                "phpunit/php-code-coverage": "^9.0|^10.0|^11.0",
                 "phpunit/phpunit": "^9.5.24|^10.5|^11.5",
                 "spatie/pest-plugin-test-time": "^1.1|^2.2"
             },
@@ -6726,7 +6727,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.3"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.92.4"
             },
             "funding": [
                 {
@@ -6734,7 +6735,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-10T21:50:03+00:00"
+            "time": "2025-04-11T15:27:14+00:00"
         },
         {
             "name": "spatie/laravel-permission",
@@ -13019,5 +13020,5 @@
         "ext-fileinfo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -290,7 +290,7 @@ class DemoSeeder extends Seeder
                     'auditor_notes' => 'Audit performed on this standard.',
                     'status' => array_rand([WorkflowStatus::COMPLETED->value => WorkflowStatus::COMPLETED, WorkflowStatus::INPROGRESS->value => WorkflowStatus::INPROGRESS, WorkflowStatus::NOTSTARTED->value => WorkflowStatus::NOTSTARTED], 1),
                     'effectiveness' => array_rand([Effectiveness::EFFECTIVE->value => Effectiveness::EFFECTIVE, Effectiveness::PARTIAL->value => Effectiveness::PARTIAL, Effectiveness::INEFFECTIVE->value => Effectiveness::INEFFECTIVE, Effectiveness::UNKNOWN->value => Effectiveness::UNKNOWN], 1),
-                    'applicability' => array_rand([Applicability::UNKNOWN->value => Applicability::UNKNOWN, Applicability::NOTAPPLICABLE->value => Applicability::NOTAPPLICABLE, Applicability::APPLICABLE->value => Applicability::APPLICABLE], 1),
+                    'applicability' => array_rand([Applicability::NOTAPPLICABLE->value => Applicability::UNKNOWN, Applicability::NOTAPPLICABLE->value => Applicability::NOTAPPLICABLE, Applicability::APPLICABLE->value => Applicability::APPLICABLE], 1),
                     'auditable_type' => Control::class,
                     'auditable_id' => $ctl->id,
                 ]

--- a/lang/en/audit.php
+++ b/lang/en/audit.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Audits',
+        'group' => 'Foundations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Audits',
+    ],
+    'table' => [
+        'empty_state' => [
+            'heading' => 'No Audits Created',
+            'description' => 'Try creating a new audit by clicking the "Create an Audit" button above to get started!',
+        ],
+        'columns' => [
+            'title' => 'Title',
+            'audit_type' => 'Audit Type',
+            'status' => 'Status',
+            'manager' => 'Manager',
+            'start_date' => 'Start Date',
+            'end_date' => 'End Date',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+        ],
+    ],
+    'infolist' => [
+        'section' => [
+            'title' => 'Audit Details',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Create Audit',
+    ],
+]; 

--- a/lang/en/control.php
+++ b/lang/en/control.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Controls',
+        'group' => 'Foundations',
+    ],
+    'model' => [
+        'label' => 'Control',
+        'plural_label' => 'Controls',
+    ],
+    'breadcrumb' => [
+        'title' => 'Controls',
+    ],
+    'form' => [
+        'code' => [
+            'tooltip' => 'Enter a unique code for this control. This code will be used to identify this control in the system.',
+        ],
+        'standard' => [
+            'label' => 'Standard',
+            'tooltip' => 'All controls must belong to a standard. If you dont have a standard to relate this control to, consider creating a new one first.',
+        ],
+        'enforcement' => [
+            'tooltip' => 'Select an enforcement category for this control. This will help determine how this control is enforced.',
+        ],
+        'title' => [
+            'tooltip' => 'Enter a title for this control.',
+        ],
+        'description' => [
+            'tooltip' => 'Enter a description for this control. This should describe, in detail, the requirements for this control.',
+        ],
+        'discussion' => [
+            'tooltip' => 'Optional: Provide any context or additional information about this control that would help someone determine how to implement it.',
+        ],
+        'test' => [
+            'label' => 'Test Plan',
+            'tooltip' => 'Optional: How do you plan to test that this control is in place and effective?',
+        ],
+    ],
+    'table' => [
+        'description' => 'Controls represent the specific security measures implemented within your organization.',
+        'empty_state' => [
+            'heading' => 'No controls found',
+            'description' => 'Get started by importing a standard bundle or creating a new control.',
+        ],
+        'columns' => [
+            'code' => 'Code',
+            'title' => 'Title',
+            'standard' => 'Standard',
+            'type' => 'Type',
+            'category' => 'Category',
+            'enforcement' => 'Enforcement',
+            'effectiveness' => 'Effectiveness',
+            'applicability' => 'Applicability',
+            'assessed' => 'Last Assessed',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+        ],
+        'filters' => [
+            'standard' => 'Standard',
+            'effectiveness' => 'Effectiveness',
+            'type' => 'Type',
+            'category' => 'Category',
+            'enforcement' => 'Enforcement',
+            'applicability' => 'Applicability',
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Control Details',
+        'test_plan' => 'Test Plan',
+    ],
+]; 

--- a/lang/en/enums.php
+++ b/lang/en/enums.php
@@ -1,0 +1,86 @@
+<?php
+
+return [
+    'workflow_status' => [
+        'not_started' => 'Not Started',
+        'in_progress' => 'In Progress',
+        'completed' => 'Completed',
+        'unknown' => 'Unknown',
+    ],
+    'effectiveness' => [
+        'effective' => 'Effective',
+        'partial' => 'Partially Effective',
+        'ineffective' => 'Ineffective',
+        'unknown' => 'Unknown',
+    ],
+    'applicability' => [
+        'applicable' => 'Applicable',
+        'not_applicable' => 'Not Applicable',
+        'partially_applicable' => 'Partially Applicable',
+    ],
+    'control_category' => [
+        'preventive' => 'Preventive',
+        'detective' => 'Detective',
+        'corrective' => 'Corrective',
+        'deterrent' => 'Deterrent',
+        'compensating' => 'Compensating',
+        'recovery' => 'Recovery',
+        'other' => 'Other',
+        'unknown' => 'Unknown',
+    ],
+    'control_enforcement' => [
+        'automated' => 'Automated',
+        'manual' => 'Manual',
+        'hybrid' => 'Hybrid',
+    ],
+    'control_type' => [
+        'technical' => 'Technical',
+        'administrative' => 'Administrative',
+        'physical' => 'Physical',
+        'operational' => 'Operational',
+        'other' => 'Other',
+    ],
+    'implementation_status' => [
+        'implemented' => 'Implemented',
+        'not_implemented' => 'Not Implemented',
+        'in_progress' => 'In Progress',
+        'planned' => 'Planned',
+    ],
+    'response_status' => [
+        'pending' => 'Pending',
+        'in_progress' => 'In Progress',
+        'completed' => 'Completed',
+        'rejected' => 'Rejected',
+    ],
+    'risk_level' => [
+        'low' => 'Low',
+        'medium' => 'Medium',
+        'high' => 'High',
+        'critical' => 'Critical',
+    ],
+    'risk_status' => [
+        'open' => 'Open',
+        'mitigated' => 'Mitigated',
+        'accepted' => 'Accepted',
+        'transferred' => 'Transferred',
+    ],
+    'standard_status' => [
+        'draft' => 'Draft',
+        'published' => 'Published',
+        'retired' => 'Retired',
+        'in_scope' => 'In Scope',
+        'out_of_scope' => 'Out of Scope',
+    ],
+    'mitigation_type' => [
+        'avoid' => 'Avoid',
+        'mitigate' => 'Mitigate',
+        'transfer' => 'Transfer',
+        'accept' => 'Accept',
+    ],
+    'control_enforcement_category' => [
+        'mandatory' => 'Mandatory',
+        'addressable' => 'Addressable',
+        'optional' => 'Optional',
+        'other' => 'Other',
+    ],
+]; 

--- a/lang/en/implementation.php
+++ b/lang/en/implementation.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Implementations',
+        'group' => 'Foundations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Implementations',
+    ],
+    'table' => [
+        'description' => 'Implementations represent the actual deployment and operation of security controls within an organization. They are the specific instances of how controls are put into practice, including the tools, configurations, processes, and procedures used. Each implementation should be documented with sufficient detail to understand how the control is operating, who is responsible for maintaining it, and how its effectiveness can be verified. For example, while a control might specify the need for access reviews, an implementation would detail the exact process, including which tool is used, who conducts the reviews, how often they occur, and what documentation is maintained. Implementations bridge the gap between theoretical security controls and their practical application in the organization.',
+        'empty_state' => [
+            'heading' => 'No implementations found',
+            'description' => 'Try creating a new implementation by clicking the "Create Implementation" button above.',
+        ],
+        'columns' => [
+            'code' => 'Code',
+            'title' => 'Title',
+            'effectiveness' => 'Effectiveness',
+            'last_assessed' => 'Last Audit',
+            'status' => 'Status',
+            'created_at' => 'Created At',
+            'updated_at' => 'Updated At',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Create Implementation',
+    ],
+]; 

--- a/lang/en/programs.php
+++ b/lang/en/programs.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'heading' => 'Programs',
+    'labels' => [
+        'singular' => 'Program',
+        'plural' => 'Programs',
+    ],
+    'form' => [
+        'name' => 'Name',
+        'description' => 'Description',
+        'program_manager' => 'Program Manager',
+        'scope_status' => 'Scope Status',
+    ],
+    'table' => [
+        'name' => 'Name',
+        'program_manager' => 'Program Manager',
+        'last_audit_date' => 'Last Audit Date',
+        'scope_status' => 'Scope Status',
+        'created_at' => 'Created At',
+        'updated_at' => 'Updated At',
+    ],
+    'scope_status' => [
+        'in_scope' => 'In Scope',
+        'out_of_scope' => 'Out of Scope',
+        'pending_review' => 'Pending Review',
+    ],
+    'description' => 'Programs serve as comprehensive frameworks that unite security standards and controls into cohesive, manageable initiatives within an organization. They represent structured approaches to achieving specific security objectives by combining relevant standards (which define \'what\' needs to be done) with appropriate controls (which specify \'how\' to do it). Each program typically addresses a distinct area of compliance, risk management, or security enhancement, making it easier to track progress, measure effectiveness, and ensure accountability. For example, a Data Privacy Program might incorporate standards from GDPR and CCPA, implementing specific controls like data encryption, access management, and regular audits to meet these requirements. By organizing security measures into programs, organizations can better coordinate their security efforts, allocate resources effectively, and maintain clear oversight of their security posture across different domains and objectives.',
+]; 

--- a/lang/en/standard.php
+++ b/lang/en/standard.php
@@ -1,0 +1,77 @@
+<?php
+
+return [
+    'form' => [
+        'name' => [
+            'placeholder' => 'e.g. Critical Security Controls, Version 8',
+            'hint' => 'Enter the name of the standard.',
+            'tooltip' => 'Need some more information?',
+        ],
+        'code' => [
+            'placeholder' => 'e.g. CSCv8',
+            'tooltip' => 'Give the standard a unique ID or Code.',
+        ],
+        'authority' => [
+            'placeholder' => 'e.g. Center for Internet Security',
+            'tooltip' => 'Enter the name of the organization that maintains the standard.',
+        ],
+        'status' => [
+            'tooltip' => 'Select the relevance of this standard to your organization.',
+        ],
+        'reference_url' => [
+            'placeholder' => 'e.g. https://www.cisecurity.org/controls/',
+            'tooltip' => 'Enter the URL of the official standard document.',
+        ],
+        'description' => [
+            'hint' => 'Describe the purpose and scope of the standard.',
+            'placeholder' => 'Description',
+        ],
+    ],
+    'table' => [
+        'description' => 'Standards define the \'what\' in security and compliance by establishing specific requirements, guidelines, or best practices that need to be followed. They serve as benchmarks against which an organization\'s security posture can be measured. Standards can originate from various sources, including regulatory bodies (like HIPAA or GDPR), industry frameworks (such as ISO 27001 or NIST), or internal organizational policies. Each standard typically outlines specific criteria that must be met to achieve compliance or maintain security. For example, a password standard might specify minimum length requirements, complexity rules, and expiration periods. Standards provide the foundation for controls, which then implement these requirements in practical ways.',
+        'empty_state' => [
+            'heading' => 'No standards found',
+            'description' => 'Get started by importing a standard bundle or creating a new standard.',
+        ],
+        'columns' => [
+            'code' => 'Standard Code',
+            'name' => 'Standard Name',
+            'description' => 'Standard Description',
+            'authority' => 'Issuing Authority',
+            'status' => 'Standard Status',
+        ],
+        'filters' => [
+            'status' => 'Standard Status',
+            'authority' => 'Issuing Authority',
+        ],
+        'actions' => [
+            'group_label' => 'Actions',
+            'set_in_scope' => [
+                'label' => 'Set In Scope',
+                'modal_heading' => 'Set Standard In Scope',
+                'modal_content' => 'Are you sure you want to set this standard in scope? This will make it available for auditing.',
+                'submit_label' => 'Set In Scope',
+            ],
+            'set_out_scope' => [
+                'label' => 'Set Out of Scope',
+                'modal_heading' => 'Set Standard Out of Scope',
+                'modal_content' => 'Are you sure you want to set this standard out of scope? This will make it unavailable for auditing.',
+                'submit_label' => 'Set Out of Scope',
+            ],
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Standard Details',
+    ],
+    'navigation' => [
+        'label' => 'Standards',
+        'group' => 'Foundations',
+    ],
+    'model' => [
+        'label' => 'Standard',
+        'plural_label' => 'Standards',
+    ],
+    'breadcrumb' => [
+        'title' => 'Standards',
+    ],
+]; 

--- a/lang/en/widgets.php
+++ b/lang/en/widgets.php
@@ -24,6 +24,7 @@ return [
 
     // Audit List Widget
     'audit_list' => [
+        'heading' => 'Audit List (Top-5)',
         'empty_heading' => 'No Audits to Show',
         'empty_description' => 'You have not created any audits yet. Create an Audit to get started.',
         'manager' => 'Manager',

--- a/lang/es/audit.php
+++ b/lang/es/audit.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Auditorías',
+        'group' => 'Fundamentos',
+    ],
+    'breadcrumb' => [
+        'title' => 'Auditorías',
+    ],
+    'table' => [
+        'empty_state' => [
+            'heading' => 'No hay auditorías creadas',
+            'description' => '¡Intente crear una nueva auditoría haciendo clic en el botón "Crear una Auditoría" de arriba para comenzar!',
+        ],
+        'columns' => [
+            'title' => 'Título',
+            'audit_type' => 'Tipo de Auditoría',
+            'status' => 'Estado',
+            'manager' => 'Gerente',
+            'start_date' => 'Fecha de Inicio',
+            'end_date' => 'Fecha de Finalización',
+            'created_at' => 'Creado El',
+            'updated_at' => 'Actualizado El',
+        ],
+    ],
+    'infolist' => [
+        'section' => [
+            'title' => 'Detalles de la Auditoría',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Crear Auditoría',
+    ],
+]; 

--- a/lang/es/control.php
+++ b/lang/es/control.php
@@ -1,0 +1,68 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Controles',
+        'group' => 'Fundamentos',
+    ],
+    'model' => [
+        'label' => 'Control',
+        'plural_label' => 'Controles',
+    ],
+    'breadcrumb' => [
+        'title' => 'Controles',
+    ],
+    'form' => [
+        'code' => [
+            'tooltip' => 'Ingrese un código único para este control. Este código se utilizará para identificar este control en el sistema.',
+        ],
+        'standard' => [
+            'label' => 'Estándar',
+            'tooltip' => 'Todos los controles deben pertenecer a un estándar. Si no tiene un estándar para relacionar este control, considere crear uno primero.',
+        ],
+        'enforcement' => [
+            'tooltip' => 'Seleccione una categoría de cumplimiento para este control. Esto ayudará a determinar cómo se aplica este control.',
+        ],
+        'title' => [
+            'tooltip' => 'Ingrese un título para este control.',
+        ],
+        'description' => [
+            'tooltip' => 'Ingrese una descripción para este control. Esto debe describir, en detalle, los requisitos para este control.',
+        ],
+        'discussion' => [
+            'tooltip' => 'Opcional: Proporcione cualquier contexto o información adicional sobre este control que ayude a alguien a determinar cómo implementarlo.',
+        ],
+        'test' => [
+            'label' => 'Plan de Prueba',
+            'tooltip' => 'Opcional: ¿Cómo planea probar que este control está implementado y es efectivo?',
+        ],
+    ],
+    'table' => [
+        'description' => 'Los controles son medidas específicas de seguridad que implementamos.',
+        'empty_state' => [
+            'heading' => 'No se encontraron controles',
+            'description' => 'Comience importando un paquete de controles o creando un nuevo control.',
+        ],
+        'columns' => [
+            'code' => 'Código del Control',
+            'title' => 'Título del Control',
+            'type' => 'Tipo de Control',
+            'category' => 'Categoría del Control',
+            'enforcement' => 'Nivel de Cumplimiento',
+            'effectiveness' => 'Efectividad',
+            'applicability' => 'Aplicabilidad',
+            'assessed' => 'Última Evaluación',
+            'created_at' => 'Creado El',
+            'updated_at' => 'Actualizado El',
+        ],
+        'filters' => [
+            'type' => 'Tipo de Control',
+            'category' => 'Categoría del Control',
+            'enforcement' => 'Nivel de Cumplimiento',
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Detalles del Control',
+        'test_plan' => 'Plan de Prueba',
+    ],
+]; 

--- a/lang/es/enums.php
+++ b/lang/es/enums.php
@@ -1,0 +1,86 @@
+<?php
+
+return [
+    'workflow_status' => [
+        'not_started' => 'No Iniciado',
+        'in_progress' => 'En Progreso',
+        'completed' => 'Completado',
+        'unknown' => 'Desconocido',
+    ],
+    'effectiveness' => [
+        'effective' => 'Efectivo',
+        'partial' => 'Parcialmente Efectivo',
+        'ineffective' => 'Inefectivo',
+        'unknown' => 'Desconocido',
+    ],
+    'applicability' => [
+        'applicable' => 'Aplicable',
+        'not_applicable' => 'No Aplicable',
+        'partially_applicable' => 'Parcialmente Aplicable',
+    ],
+    'control_category' => [
+        'preventive' => 'Preventivo',
+        'detective' => 'Detective',
+        'corrective' => 'Correctivo',
+        'deterrent' => 'Disuasivo',
+        'compensating' => 'Compensatorio',
+        'recovery' => 'Recuperación',
+        'other' => 'Otro',
+        'unknown' => 'Desconocido',
+    ],
+    'control_enforcement' => [
+        'automated' => 'Automatizado',
+        'manual' => 'Manual',
+        'hybrid' => 'Híbrido',
+    ],
+    'control_type' => [
+        'technical' => 'Técnico',
+        'administrative' => 'Administrativo',
+        'physical' => 'Físico',
+        'operational' => 'Operacional',
+        'other' => 'Otro',
+    ],
+    'implementation_status' => [
+        'implemented' => 'Implementado',
+        'not_implemented' => 'No Implementado',
+        'in_progress' => 'En Progreso',
+        'planned' => 'Planificado',
+    ],
+    'response_status' => [
+        'pending' => 'Pendiente',
+        'in_progress' => 'En Progreso',
+        'completed' => 'Completado',
+        'rejected' => 'Rechazado',
+    ],
+    'risk_level' => [
+        'low' => 'Bajo',
+        'medium' => 'Medio',
+        'high' => 'Alto',
+        'critical' => 'Crítico',
+    ],
+    'risk_status' => [
+        'open' => 'Abierto',
+        'mitigated' => 'Mitigado',
+        'accepted' => 'Aceptado',
+        'transferred' => 'Transferido',
+    ],
+    'standard_status' => [
+        'draft' => 'Borrador',
+        'published' => 'Publicado',
+        'retired' => 'Retirado',
+        'in_scope' => 'En Alcance',
+        'out_of_scope' => 'Fuera de Alcance',
+    ],
+    'mitigation_type' => [
+        'avoid' => 'Evitar',
+        'mitigate' => 'Mitigar',
+        'transfer' => 'Transferir',
+        'accept' => 'Aceptar',
+    ],
+    'control_enforcement_category' => [
+        'mandatory' => 'Obligatorio',
+        'addressable' => 'Abordable',
+        'optional' => 'Opcional',
+        'other' => 'Otro',
+    ],
+]; 

--- a/lang/es/implementation.php
+++ b/lang/es/implementation.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Implementaciones',
+        'group' => 'Fundamentos',
+    ],
+    'breadcrumb' => [
+        'title' => 'Implementaciones',
+    ],
+    'table' => [
+        'description' => 'Las implementaciones representan el despliegue y operación real de los controles de seguridad dentro de una organización. Son las instancias específicas de cómo se ponen en práctica los controles, incluyendo las herramientas, configuraciones, procesos y procedimientos utilizados. Cada implementación debe documentarse con suficiente detalle para comprender cómo está operando el control, quién es responsable de mantenerlo y cómo se puede verificar su efectividad. Por ejemplo, mientras que un control puede especificar la necesidad de revisiones de acceso, una implementación detallaría el proceso exacto, incluyendo qué herramienta se utiliza, quién realiza las revisiones, con qué frecuencia ocurren y qué documentación se mantiene. Las implementaciones conectan la brecha entre los controles de seguridad teóricos y su aplicación práctica en la organización.',
+        'empty_state' => [
+            'heading' => 'No se encontraron implementaciones',
+            'description' => 'Intente crear una nueva implementación haciendo clic en el botón "Crear Implementación" de arriba.',
+        ],
+        'columns' => [
+            'code' => 'Código',
+            'title' => 'Título',
+            'effectiveness' => 'Efectividad',
+            'last_assessed' => 'Última Auditoría',
+            'status' => 'Estado',
+            'created_at' => 'Creado El',
+            'updated_at' => 'Actualizado El',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Crear Implementación',
+    ],
+]; 

--- a/lang/es/programs.php
+++ b/lang/es/programs.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'heading' => 'Programas',
+    'labels' => [
+        'singular' => 'Programa',
+        'plural' => 'Programas',
+    ],
+    'form' => [
+        'name' => 'Nombre',
+        'description' => 'Descripción',
+        'program_manager' => 'Gerente del Programa',
+        'scope_status' => 'Estado del Alcance',
+    ],
+    'table' => [
+        'name' => 'Nombre',
+        'program_manager' => 'Gerente del Programa',
+        'last_audit_date' => 'Última Fecha de Auditoría',
+        'scope_status' => 'Estado del Alcance',
+        'created_at' => 'Creado el',
+        'updated_at' => 'Actualizado el',
+    ],
+    'scope_status' => [
+        'in_scope' => 'En Alcance',
+        'out_of_scope' => 'Fuera de Alcance',
+        'pending_review' => 'Revisión Pendiente',
+    ],
+    'description' => 'Los programas sirven como marcos integrales que unen estándares y controles de seguridad en iniciativas cohesivas y manejables dentro de una organización. Representan enfoques estructurados para lograr objetivos específicos de seguridad al combinar estándares relevantes (que definen \'qué\' debe hacerse) con controles apropiados (que especifican \'cómo\' hacerlo). Cada programa típicamente aborda un área distinta de cumplimiento, gestión de riesgos o mejora de seguridad, facilitando el seguimiento del progreso, la medición de la efectividad y la garantía de responsabilidad. Por ejemplo, un Programa de Privacidad de Datos podría incorporar estándares de GDPR y CCPA, implementando controles específicos como cifrado de datos, gestión de accesos y auditorías regulares para cumplir con estos requisitos. Al organizar las medidas de seguridad en programas, las organizaciones pueden coordinar mejor sus esfuerzos de seguridad, asignar recursos de manera efectiva y mantener una supervisión clara de su postura de seguridad en diferentes dominios y objetivos.',
+]; 

--- a/lang/es/standard.php
+++ b/lang/es/standard.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Estándares',
+        'group' => 'Fundamentos',
+    ],
+    'model' => [
+        'label' => 'Estándar',
+        'plural_label' => 'Estándares',
+    ],
+    'breadcrumb' => [
+        'title' => 'Estándares',
+    ],
+    'table' => [
+        'description' => 'Los estándares definen el \'qué\' en seguridad y cumplimiento al establecer requisitos específicos, pautas o mejores prácticas que deben seguirse. Sirven como puntos de referencia contra los cuales se puede medir la postura de seguridad de una organización. Los estándares pueden originarse de diversas fuentes, incluyendo organismos reguladores (como HIPAA o GDPR), marcos de la industria (como ISO 27001 o NIST), o políticas organizativas internas. Cada estándar típicamente describe criterios específicos que deben cumplirse para lograr el cumplimiento o mantener la seguridad. Por ejemplo, un estándar de contraseñas puede especificar requisitos de longitud mínima, reglas de complejidad y períodos de caducidad. Los estándares proporcionan la base para los controles, que luego implementan estos requisitos de manera práctica.',
+        'empty_state' => [
+            'heading' => 'No se encontraron estándares',
+            'description' => 'Comience importando un paquete de estándares o creando un nuevo estándar.',
+        ],
+        'columns' => [
+            'code' => 'Código del Estándar',
+            'name' => 'Nombre del Estándar',
+            'description' => 'Descripción del Estándar',
+            'authority' => 'Autoridad Emisora',
+            'status' => 'Estado del Estándar',
+        ],
+        'filters' => [
+            'status' => 'Estado del Estándar',
+            'authority' => 'Autoridad Emisora',
+        ],
+        'actions' => [
+            'group_label' => 'Acciones',
+            'set_in_scope' => [
+                'label' => 'Establecer En Alcance',
+                'modal_heading' => 'Establecer Estándar En Alcance',
+                'modal_content' => '¿Está seguro de que desea establecer este estándar en alcance? Esto lo hará disponible para auditoría.',
+                'submit_label' => 'Establecer En Alcance',
+            ],
+            'set_out_scope' => [
+                'label' => 'Establecer Fuera de Alcance',
+                'modal_heading' => 'Establecer Estándar Fuera de Alcance',
+                'modal_content' => '¿Está seguro de que desea establecer este estándar fuera de alcance? Esto lo hará no disponible para auditoría.',
+                'submit_label' => 'Establecer Fuera de Alcance',
+            ],
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Detalles del Estándar',
+    ],
+]; 

--- a/lang/es/widgets.php
+++ b/lang/es/widgets.php
@@ -24,6 +24,7 @@ return [
 
     // Audit List Widget
     'audit_list' => [
+        'heading' => 'Lista de Auditorías (Top-5)',
         'empty_heading' => 'No Hay Auditorías para Mostrar',
         'empty_description' => 'No has creado ninguna auditoría todavía. Crea una Auditoría para comenzar.',
         'manager' => 'Gerente',

--- a/lang/fr/audit.php
+++ b/lang/fr/audit.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Audits',
+        'group' => 'Fondations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Audits',
+    ],
+    'table' => [
+        'empty_state' => [
+            'heading' => 'Aucun audit créé',
+            'description' => 'Essayez de créer un nouvel audit en cliquant sur le bouton "Créer un Audit" ci-dessus pour commencer !',
+        ],
+        'columns' => [
+            'title' => 'Titre',
+            'audit_type' => 'Type d\'Audit',
+            'status' => 'Statut',
+            'manager' => 'Gestionnaire',
+            'start_date' => 'Date de Début',
+            'end_date' => 'Date de Fin',
+            'created_at' => 'Créé Le',
+            'updated_at' => 'Mis à Jour Le',
+        ],
+    ],
+    'infolist' => [
+        'section' => [
+            'title' => 'Détails de l\'Audit',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Créer un Audit',
+    ],
+]; 

--- a/lang/fr/control.php
+++ b/lang/fr/control.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Contrôles',
+        'group' => 'Fondations',
+    ],
+    'model' => [
+        'label' => 'Contrôle',
+        'plural_label' => 'Contrôles',
+    ],
+    'breadcrumb' => [
+        'title' => 'Contrôles',
+    ],
+    'form' => [
+        'code' => [
+            'tooltip' => 'Entrez un code unique pour ce contrôle. Ce code sera utilisé pour identifier ce contrôle dans le système.',
+        ],
+        'standard' => [
+            'label' => 'Norme',
+            'tooltip' => 'Tous les contrôles doivent appartenir à une norme. Si vous n\'avez pas de norme à laquelle rattacher ce contrôle, envisagez d\'en créer une d\'abord.',
+        ],
+        'enforcement' => [
+            'tooltip' => 'Sélectionnez une catégorie d\'application pour ce contrôle. Cela aidera à déterminer comment ce contrôle est appliqué.',
+        ],
+        'title' => [
+            'tooltip' => 'Entrez un titre pour ce contrôle.',
+        ],
+        'description' => [
+            'tooltip' => 'Entrez une description pour ce contrôle. Cela doit décrire, en détail, les exigences pour ce contrôle.',
+        ],
+        'discussion' => [
+            'tooltip' => 'Optionnel : Fournissez tout contexte ou information supplémentaire sur ce contrôle qui aiderait quelqu\'un à déterminer comment le mettre en œuvre.',
+        ],
+        'test' => [
+            'label' => 'Plan de Test',
+            'tooltip' => 'Optionnel : Comment prévoyez-vous de tester que ce contrôle est en place et efficace ?',
+        ],
+    ],
+    'table' => [
+        'description' => 'Les contrôles représentent les mesures de sécurité spécifiques mises en œuvre au sein de votre organisation.',
+        'empty_state' => [
+            'heading' => 'Aucun contrôle trouvé',
+            'description' => 'Commencez par importer un ensemble de standards ou créer un nouveau contrôle.',
+        ],
+        'columns' => [
+            'code' => 'Code du Contrôle',
+            'title' => 'Titre du Contrôle',
+            'standard' => 'Standard',
+            'type' => 'Type de Contrôle',
+            'category' => 'Catégorie du Contrôle',
+            'enforcement' => 'Niveau d\'Application',
+            'effectiveness' => 'Efficacité',
+            'applicability' => 'Applicabilité',
+            'assessed' => 'Dernière Évaluation',
+            'created_at' => 'Créé Le',
+            'updated_at' => 'Mis à Jour Le',
+        ],
+        'filters' => [
+            'standard' => 'Standard',
+            'effectiveness' => 'Efficacité',
+            'type' => 'Type',
+            'category' => 'Catégorie',
+            'enforcement' => 'Application',
+            'applicability' => 'Applicabilité',
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Détails du Contrôle',
+        'test_plan' => 'Plan de Test',
+    ],
+]; 

--- a/lang/fr/enums.php
+++ b/lang/fr/enums.php
@@ -1,0 +1,86 @@
+<?php
+
+return [
+    'workflow_status' => [
+        'not_started' => 'Non Commencé',
+        'in_progress' => 'En Cours',
+        'completed' => 'Terminé',
+        'unknown' => 'Inconnu',
+    ],
+    'effectiveness' => [
+        'effective' => 'Efficace',
+        'partial' => 'Partiellement Efficace',
+        'ineffective' => 'Inefficace',
+        'unknown' => 'Inconnu',
+    ],
+    'applicability' => [
+        'applicable' => 'Applicable',
+        'not_applicable' => 'Non Applicable',
+        'partially_applicable' => 'Partiellement Applicable',
+    ],
+    'control_category' => [
+        'preventive' => 'Préventif',
+        'detective' => 'Détectif',
+        'corrective' => 'Correctif',
+        'deterrent' => 'Dissuasif',
+        'compensating' => 'Compensatoire',
+        'recovery' => 'Récupération',
+        'other' => 'Autre',
+        'unknown' => 'Inconnu',
+    ],
+    'control_enforcement' => [
+        'automated' => 'Automatisé',
+        'manual' => 'Manuel',
+        'hybrid' => 'Hybride',
+    ],
+    'control_type' => [
+        'technical' => 'Technique',
+        'administrative' => 'Administratif',
+        'physical' => 'Physique',
+        'operational' => 'Opérationnel',
+        'other' => 'Autre',
+    ],
+    'implementation_status' => [
+        'implemented' => 'Implémenté',
+        'not_implemented' => 'Non Implémenté',
+        'in_progress' => 'En Cours',
+        'planned' => 'Planifié',
+    ],
+    'response_status' => [
+        'pending' => 'En Attente',
+        'in_progress' => 'En Cours',
+        'completed' => 'Terminé',
+        'rejected' => 'Rejeté',
+    ],
+    'risk_level' => [
+        'low' => 'Faible',
+        'medium' => 'Moyen',
+        'high' => 'Élevé',
+        'critical' => 'Critique',
+    ],
+    'risk_status' => [
+        'open' => 'Ouvert',
+        'mitigated' => 'Atténué',
+        'accepted' => 'Accepté',
+        'transferred' => 'Transféré',
+    ],
+    'standard_status' => [
+        'draft' => 'Brouillon',
+        'published' => 'Publié',
+        'retired' => 'Retiré',
+        'in_scope' => 'Dans la Portée',
+        'out_of_scope' => 'Hors de la Portée',
+    ],
+    'mitigation_type' => [
+        'avoid' => 'Éviter',
+        'mitigate' => 'Atténuer',
+        'transfer' => 'Transférer',
+        'accept' => 'Accepter',
+    ],
+    'control_enforcement_category' => [
+        'mandatory' => 'Obligatoire',
+        'addressable' => 'Traitable',
+        'optional' => 'Optionnel',
+        'other' => 'Autre',
+    ],
+]; 

--- a/lang/fr/implementation.php
+++ b/lang/fr/implementation.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Implémentations',
+        'group' => 'Fondations',
+    ],
+    'breadcrumb' => [
+        'title' => 'Implémentations',
+    ],
+    'table' => [
+        'description' => 'Les implémentations représentent le déploiement et le fonctionnement réels des contrôles de sécurité au sein d\'une organisation. Ce sont les instances spécifiques de la mise en pratique des contrôles, y compris les outils, les configurations, les processus et les procédures utilisés. Chaque implémentation doit être documentée avec suffisamment de détails pour comprendre comment le contrôle fonctionne, qui est responsable de son maintien et comment son efficacité peut être vérifiée. Par exemple, alors qu\'un contrôle peut spécifier la nécessité d\'examens d\'accès, une implémentation détaillerait le processus exact, y compris l\'outil utilisé, qui effectue les examens, à quelle fréquence ils ont lieu et quelle documentation est maintenue. Les implémentations comblent le fossé entre les contrôles de sécurité théoriques et leur application pratique dans l\'organisation.',
+        'empty_state' => [
+            'heading' => 'Aucune implémentation trouvée',
+            'description' => 'Essayez de créer une nouvelle implémentation en cliquant sur le bouton "Créer une Implémentation" ci-dessus.',
+        ],
+        'columns' => [
+            'code' => 'Code',
+            'title' => 'Titre',
+            'effectiveness' => 'Efficacité',
+            'last_assessed' => 'Dernier Audit',
+            'status' => 'Statut',
+            'created_at' => 'Créé Le',
+            'updated_at' => 'Mis à Jour Le',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Créer une Implémentation',
+    ],
+]; 

--- a/lang/fr/programs.php
+++ b/lang/fr/programs.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'heading' => 'Programmes',
+    'labels' => [
+        'singular' => 'Programme',
+        'plural' => 'Programmes',
+    ],
+    'form' => [
+        'name' => 'Nom',
+        'description' => 'Description',
+        'program_manager' => 'Gestionnaire du Programme',
+        'scope_status' => 'Statut de la Portée',
+    ],
+    'table' => [
+        'name' => 'Nom',
+        'program_manager' => 'Gestionnaire du Programme',
+        'last_audit_date' => 'Dernière Date d\'Audit',
+        'scope_status' => 'Statut de la Portée',
+        'created_at' => 'Créé le',
+        'updated_at' => 'Mis à jour le',
+    ],
+    'scope_status' => [
+        'in_scope' => 'Dans la Portée',
+        'out_of_scope' => 'Hors de la Portée',
+        'pending_review' => 'En Attente de Révision',
+    ],
+    'description' => 'Les programmes servent de cadres complets qui unissent les normes et les contrôles de sécurité en initiatives cohérentes et gérables au sein d\'une organisation. Ils représentent des approches structurées pour atteindre des objectifs de sécurité spécifiques en combinant des normes pertinentes (qui définissent \'ce qui\' doit être fait) avec des contrôles appropriés (qui spécifient \'comment\' le faire). Chaque programme aborde généralement un domaine distinct de conformité, de gestion des risques ou d\'amélioration de la sécurité, facilitant le suivi des progrès, la mesure de l\'efficacité et la garantie de la responsabilité. Par exemple, un Programme de Confidentialité des Données pourrait incorporer des normes du RGPD et du CCPA, en mettant en œuvre des contrôles spécifiques comme le chiffrement des données, la gestion des accès et des audits réguliers pour répondre à ces exigences. En organisant les mesures de sécurité en programmes, les organisations peuvent mieux coordonner leurs efforts de sécurité, allouer efficacement les ressources et maintenir une supervision claire de leur posture de sécurité à travers différents domaines et objectifs.',
+]; 

--- a/lang/fr/standard.php
+++ b/lang/fr/standard.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Standards',
+        'group' => 'Fondations',
+    ],
+    'model' => [
+        'label' => 'Standard',
+        'plural_label' => 'Standards',
+    ],
+    'breadcrumb' => [
+        'title' => 'Standards',
+    ],
+    'table' => [
+        'description' => 'Les normes définissent le \'quoi\' en matière de sécurité et de conformité en établissant des exigences spécifiques, des directives ou des meilleures pratiques à suivre. Elles servent de points de référence permettant de mesurer la posture de sécurité d\'une organisation. Les normes peuvent provenir de diverses sources, notamment des organismes de réglementation (comme HIPAA ou RGPD), des cadres industriels (tels que ISO 27001 ou NIST), ou des politiques organisationnelles internes. Chaque norme décrit généralement des critères spécifiques qui doivent être respectés pour assurer la conformité ou maintenir la sécurité. Par exemple, une norme de mot de passe peut spécifier des exigences de longueur minimale, des règles de complexité et des périodes d\'expiration. Les normes fournissent la base des contrôles, qui mettent ensuite en œuvre ces exigences de manière pratique.',
+        'empty_state' => [
+            'heading' => 'Aucune norme trouvée',
+            'description' => 'Commencez par importer un ensemble de normes ou créer une nouvelle norme.',
+        ],
+        'columns' => [
+            'code' => 'Code de la Norme',
+            'name' => 'Nom de la Norme',
+            'description' => 'Description de la Norme',
+            'authority' => 'Autorité Émettrice',
+            'status' => 'Statut de la Norme',
+        ],
+        'filters' => [
+            'status' => 'Statut de la Norme',
+            'authority' => 'Autorité Émettrice',
+        ],
+        'actions' => [
+            'group_label' => 'Actions',
+            'set_in_scope' => [
+                'label' => 'Mettre Dans le Périmètre',
+                'modal_heading' => 'Mettre le Standard Dans le Périmètre',
+                'modal_content' => 'Êtes-vous sûr de vouloir mettre ce standard dans le périmètre ? Cela le rendra disponible pour l\'audit.',
+                'submit_label' => 'Mettre Dans le Périmètre',
+            ],
+            'set_out_scope' => [
+                'label' => 'Mettre Hors Périmètre',
+                'modal_heading' => 'Mettre le Standard Hors Périmètre',
+                'modal_content' => 'Êtes-vous sûr de vouloir mettre ce standard hors périmètre ? Cela le rendra indisponible pour l\'audit.',
+                'submit_label' => 'Mettre Hors Périmètre',
+            ],
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Détails du Standard',
+    ],
+]; 

--- a/lang/fr/widgets.php
+++ b/lang/fr/widgets.php
@@ -24,6 +24,7 @@ return [
 
     // Audit List Widget
     'audit_list' => [
+        'heading' => 'Liste des Audits (Top-5)',
         'empty_heading' => 'Aucun Audit à Afficher',
         'empty_description' => 'Vous n\'avez pas encore créé d\'audits. Créez un Audit pour commencer.',
         'manager' => 'Responsable',

--- a/lang/hr/audit.php
+++ b/lang/hr/audit.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Revizije',
+        'group' => 'Temelji',
+    ],
+    'breadcrumb' => [
+        'title' => 'Revizije',
+    ],
+    'table' => [
+        'empty_state' => [
+            'heading' => 'Nema kreiranih revizija',
+            'description' => 'Pokušajte kreirati novu reviziju klikom na gumb "Kreiraj Reviziju" iznad za početak!',
+        ],
+        'columns' => [
+            'title' => 'Naslov',
+            'audit_type' => 'Vrsta Revizije',
+            'status' => 'Status',
+            'manager' => 'Upravitelj',
+            'start_date' => 'Datum Početka',
+            'end_date' => 'Datum Završetka',
+            'created_at' => 'Kreirano',
+            'updated_at' => 'Ažurirano',
+        ],
+    ],
+    'infolist' => [
+        'section' => [
+            'title' => 'Detalji Revizije',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Kreiraj Reviziju',
+    ],
+]; 

--- a/lang/hr/control.php
+++ b/lang/hr/control.php
@@ -1,0 +1,72 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Kontrole',
+        'group' => 'Temelji',
+    ],
+    'model' => [
+        'label' => 'Kontrola',
+        'plural_label' => 'Kontrole',
+    ],
+    'breadcrumb' => [
+        'title' => 'Kontrole',
+    ],
+    'form' => [
+        'code' => [
+            'tooltip' => 'Unesite jedinstveni kod za ovu kontrolu. Ovaj kod će se koristiti za identifikaciju ove kontrole u sustavu.',
+        ],
+        'standard' => [
+            'label' => 'Standard',
+            'tooltip' => 'Sve kontrole moraju pripadati standardu. Ako nemate standard za povezivanje s ovom kontrolom, prvo razmislite o stvaranju novog.',
+        ],
+        'enforcement' => [
+            'tooltip' => 'Odaberite kategoriju provedbe za ovu kontrolu. To će pomoći u određivanju kako se ova kontrola provodi.',
+        ],
+        'title' => [
+            'tooltip' => 'Unesite naslov za ovu kontrolu.',
+        ],
+        'description' => [
+            'tooltip' => 'Unesite opis za ovu kontrolu. Ovo treba detaljno opisati zahtjeve za ovu kontrolu.',
+        ],
+        'discussion' => [
+            'tooltip' => 'Opcionalno: Navedite bilo koji kontekst ili dodatne informacije o ovoj kontroli koje bi nekome pomogle odrediti kako je implementirati.',
+        ],
+        'test' => [
+            'label' => 'Plan Testiranja',
+            'tooltip' => 'Opcionalno: Kako planirate testirati je li ova kontrola implementirana i učinkovita?',
+        ],
+    ],
+    'table' => [
+        'description' => 'Kontrole predstavljaju specifične sigurnosne mjere implementirane unutar vaše organizacije.',
+        'empty_state' => [
+            'heading' => 'Nisu pronađene kontrole',
+            'description' => 'Započnite uvozom paketa standarda ili kreiranjem nove kontrole.',
+        ],
+        'columns' => [
+            'code' => 'Kod',
+            'title' => 'Naslov',
+            'standard' => 'Standard',
+            'type' => 'Tip',
+            'category' => 'Kategorija',
+            'enforcement' => 'Provedba',
+            'effectiveness' => 'Učinkovitost',
+            'applicability' => 'Primjenjivost',
+            'assessed' => 'Zadnja Procjena',
+            'created_at' => 'Kreirano',
+            'updated_at' => 'Ažurirano',
+        ],
+        'filters' => [
+            'standard' => 'Standard',
+            'effectiveness' => 'Učinkovitost',
+            'type' => 'Tip',
+            'category' => 'Kategorija',
+            'enforcement' => 'Provedba',
+            'applicability' => 'Primjenjivost',
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Detalji Kontrole',
+        'test_plan' => 'Plan Testiranja',
+    ],
+]; 

--- a/lang/hr/enums.php
+++ b/lang/hr/enums.php
@@ -1,0 +1,86 @@
+<?php
+
+return [
+    'workflow_status' => [
+        'not_started' => 'Nije Započeto',
+        'in_progress' => 'U Tijeku',
+        'completed' => 'Završeno',
+        'unknown' => 'Nepoznato',
+    ],
+    'effectiveness' => [
+        'effective' => 'Učinkovito',
+        'partial' => 'Djelomično Učinkovito',
+        'ineffective' => 'Neučinkovito',
+        'unknown' => 'Nepoznato',
+    ],
+    'applicability' => [
+        'applicable' => 'Primjenjivo',
+        'not_applicable' => 'Nije Primjenjivo',
+        'partially_applicable' => 'Djelomično Primjenjivo',
+    ],
+    'control_category' => [
+        'preventive' => 'Preventivno',
+        'detective' => 'Detektivno',
+        'corrective' => 'Korektivno',
+        'deterrent' => 'Odvraćajuće',
+        'compensating' => 'Kompenzacijsko',
+        'recovery' => 'Oporavak',
+        'other' => 'Ostalo',
+        'unknown' => 'Nepoznato',
+    ],
+    'control_enforcement' => [
+        'automated' => 'Automatizirano',
+        'manual' => 'Ručno',
+        'hybrid' => 'Hibridno',
+    ],
+    'control_type' => [
+        'technical' => 'Tehnički',
+        'administrative' => 'Administrativni',
+        'physical' => 'Fizički',
+        'operational' => 'Operativni',
+        'other' => 'Ostalo',
+    ],
+    'implementation_status' => [
+        'implemented' => 'Implementirano',
+        'not_implemented' => 'Nije Implementirano',
+        'in_progress' => 'U Tijeku',
+        'planned' => 'Planirano',
+    ],
+    'response_status' => [
+        'pending' => 'Na Čekanju',
+        'in_progress' => 'U Tijeku',
+        'completed' => 'Završeno',
+        'rejected' => 'Odbijeno',
+    ],
+    'risk_level' => [
+        'low' => 'Nisko',
+        'medium' => 'Srednje',
+        'high' => 'Visoko',
+        'critical' => 'Kritično',
+    ],
+    'risk_status' => [
+        'open' => 'Otvoreno',
+        'mitigated' => 'Ublaženo',
+        'accepted' => 'Prihvaćeno',
+        'transferred' => 'Preneseno',
+    ],
+    'standard_status' => [
+        'draft' => 'Nacrt',
+        'published' => 'Objavljeno',
+        'retired' => 'Povučeno',
+        'in_scope' => 'U Opsegu',
+        'out_of_scope' => 'Izvan Opsega',
+    ],
+    'mitigation_type' => [
+        'avoid' => 'Izbjegavanje',
+        'mitigate' => 'Ublažavanje',
+        'transfer' => 'Prijenos',
+        'accept' => 'Prihvaćanje',
+    ],
+    'control_enforcement_category' => [
+        'mandatory' => 'Obavezno',
+        'addressable' => 'Rješivo',
+        'optional' => 'Opcionalno',
+        'other' => 'Ostalo',
+    ],
+]; 

--- a/lang/hr/implementation.php
+++ b/lang/hr/implementation.php
@@ -1,0 +1,30 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Implementacije',
+        'group' => 'Temelji',
+    ],
+    'breadcrumb' => [
+        'title' => 'Implementacije',
+    ],
+    'table' => [
+        'description' => 'Implementacije predstavljaju stvarno uvođenje i rad sigurnosnih kontrola unutar organizacije. To su specifični primjeri kako se kontrole provode u praksi, uključujući korištene alate, konfiguracije, procese i procedure. Svaka implementacija mora biti dokumentirana s dovoljno detalja da se razumije kako kontrola funkcionira, tko je odgovoran za njeno održavanje i kako se može provjeriti njena učinkovitost. Na primjer, dok kontrola može specificirati potrebu za pregledima pristupa, implementacija bi detaljno opisala točan proces, uključujući koji se alat koristi, tko provodi preglede, koliko često se događaju i koja se dokumentacija održava. Implementacije premošćuju jaz između teoretskih sigurnosnih kontrola i njihove praktične primjene u organizaciji.',
+        'empty_state' => [
+            'heading' => 'Nisu pronađene implementacije',
+            'description' => 'Pokušajte kreirati novu implementaciju klikom na gumb "Kreiraj Implementaciju" iznad.',
+        ],
+        'columns' => [
+            'code' => 'Kod',
+            'title' => 'Naslov',
+            'effectiveness' => 'Učinkovitost',
+            'last_assessed' => 'Zadnja Revizija',
+            'status' => 'Status',
+            'created_at' => 'Kreirano',
+            'updated_at' => 'Ažurirano',
+        ],
+    ],
+    'actions' => [
+        'create' => 'Kreiraj Implementaciju',
+    ],
+]; 

--- a/lang/hr/programs.php
+++ b/lang/hr/programs.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'heading' => 'Programi',
+    'labels' => [
+        'singular' => 'Program',
+        'plural' => 'Programi',
+    ],
+    'form' => [
+        'name' => 'Naziv',
+        'description' => 'Opis',
+        'program_manager' => 'Voditelj Programa',
+        'scope_status' => 'Status Opsega',
+    ],
+    'table' => [
+        'name' => 'Naziv',
+        'program_manager' => 'Voditelj Programa',
+        'last_audit_date' => 'Datum Zadnje Revizije',
+        'scope_status' => 'Status Opsega',
+        'created_at' => 'Kreirano',
+        'updated_at' => 'Ažurirano',
+    ],
+    'scope_status' => [
+        'in_scope' => 'U Opsegu',
+        'out_of_scope' => 'Izvan Opsega',
+        'pending_review' => 'Na Čekanju Pregleda',
+    ],
+    'description' => 'Programi služe kao sveobuhvatni okviri koji ujedinjuju sigurnosne standarde i kontrole u kohezivne, upravljive inicijative unutar organizacije. Oni predstavljaju strukturirane pristupe postizanju specifičnih sigurnosnih ciljeva kombiniranjem relevantnih standarda (koji definiraju \'što\' treba učiniti) s odgovarajućim kontrolama (koje određuju \'kako\' to učiniti). Svaki program obično se bavi različitim područjem usklađenosti, upravljanja rizicima ili poboljšanja sigurnosti, olakšavajući praćenje napretka, mjerenje učinkovitosti i osiguravanje odgovornosti. Na primjer, Program zaštite podataka mogao bi uključivati standarde iz GDPR-a i CCPA-a, implementirajući specifične kontrole poput enkripcije podataka, upravljanja pristupom i redovitih revizija kako bi se zadovoljili ovi zahtjevi. Organiziranjem sigurnosnih mjera u programe, organizacije mogu bolje koordinirati svoje sigurnosne napore, učinkovito rasporediti resurse i održavati jasan nadzor nad svojim sigurnosnim položajem kroz različite domene i ciljeve.',
+]; 

--- a/lang/hr/standard.php
+++ b/lang/hr/standard.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+    'navigation' => [
+        'label' => 'Standardi',
+        'group' => 'Temelji',
+    ],
+    'model' => [
+        'label' => 'Standard',
+        'plural_label' => 'Standardi',
+    ],
+    'breadcrumb' => [
+        'title' => 'Standardi',
+    ],
+    'table' => [
+        'description' => 'Standardi definiraju \'što\' u sigurnosti i usklađenosti postavljanjem specifičnih zahtjeva, smjernica ili najboljih praksi koje treba slijediti. Služe kao mjerila prema kojima se može mjeriti sigurnosni položaj organizacije. Standardi mogu potjecati iz različitih izvora, uključujući regulatorna tijela (poput HIPAA ili GDPR-a), industrijske okvire (kao što su ISO 27001 ili NIST) ili interne organizacijske politike. Svaki standard obično opisuje specifične kriterije koji se moraju ispuniti kako bi se postigla usklađenost ili održala sigurnost. Na primjer, standard za lozinke može odrediti zahtjeve minimalne duljine, pravila složenosti i razdoblja isteka. Standardi pružaju temelj za kontrole, koje zatim implementiraju ove zahtjeve na praktičan način.',
+        'empty_state' => [
+            'heading' => 'Nisu pronađeni standardi',
+            'description' => 'Započnite uvozom paketa standarda ili stvaranjem novog standarda.',
+        ],
+        'columns' => [
+            'code' => 'Kod Standarda',
+            'name' => 'Naziv Standarda',
+            'description' => 'Opis Standarda',
+            'authority' => 'Izdavatelj',
+            'status' => 'Status Standarda',
+        ],
+        'filters' => [
+            'status' => 'Status Standarda',
+            'authority' => 'Izdavatelj',
+        ],
+        'actions' => [
+            'group_label' => 'Akcije',
+            'set_in_scope' => [
+                'label' => 'Postavi U Opseg',
+                'modal_heading' => 'Postavi Standard U Opseg',
+                'modal_content' => 'Jeste li sigurni da želite postaviti ovaj standard u opseg? To će ga učiniti dostupnim za reviziju.',
+                'submit_label' => 'Postavi U Opseg',
+            ],
+            'set_out_scope' => [
+                'label' => 'Postavi Izvan Opsega',
+                'modal_heading' => 'Postavi Standard Izvan Opsega',
+                'modal_content' => 'Jeste li sigurni da želite postaviti ovaj standard izvan opsega? To će ga učiniti nedostupnim za reviziju.',
+                'submit_label' => 'Postavi Izvan Opsega',
+            ],
+        ],
+    ],
+    'infolist' => [
+        'section_title' => 'Detalji Standarda',
+    ],
+]; 

--- a/lang/hr/widgets.php
+++ b/lang/hr/widgets.php
@@ -24,6 +24,7 @@ return [
 
     // Audit List Widget
     'audit_list' => [
+        'heading' => 'Popis Revizija (Top-5)',
         'empty_heading' => 'Nema Revizija za Prikaz',
         'empty_description' => 'Još niste stvorili nijednu reviziju. Stvorite Reviziju za početak.',
         'manager' => 'Voditelj',


### PR DESCRIPTION
- Add language files for audit, control, enums, implementation, programs, and standard
- Update widgets translations for all supported languages
- Implement translations for all enums
- Update Filament resources to use translation keys
- Modify DemoSeeder to support localized content