### PR TITLE
remove riskOwner from indexRelations on risk controller

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -247,7 +247,7 @@ GET /api/controls/1?with=standard,implementations
 
 **Searchable Fields:** `title`, `description`, `mitigation`
 
-**Relations:** `riskOwner`, `implementations`
+**Relations:** `implementations`
 
 ### Vendors
 

--- a/app/Http/Controllers/API/RiskController.php
+++ b/app/Http/Controllers/API/RiskController.php
@@ -11,9 +11,7 @@ class RiskController extends BaseApiController
 
     protected string $resourceName = 'Risks';
 
-    protected array $indexRelations = ['riskOwner'];
-
-    protected array $showRelations = ['riskOwner', 'implementations'];
+    protected array $showRelations = ['implementations'];
 
     protected array $searchableFields = ['title', 'description', 'mitigation'];
 


### PR DESCRIPTION
This relation only exists on the `RiskController` and not on the `Risk` model - it is eager fetched and breaks the get apis. This is detailed in the issue -> #158 