### PR TITLE
fix: Add missing contact fields to vendors table

### DIFF
--- a/database/migrations/2025_12_23_000001_add_contact_fields_to_vendors_table.php
+++ b/database/migrations/2025_12_23_000001_add_contact_fields_to_vendors_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vendors', function (Blueprint $table) {
+            if (! Schema::hasColumn('vendors', 'contact_name')) {
+                $table->string('contact_name')->nullable()->after('logo');
+            }
+            if (! Schema::hasColumn('vendors', 'contact_email')) {
+                $table->string('contact_email')->nullable()->after('contact_name');
+            }
+            if (! Schema::hasColumn('vendors', 'contact_phone')) {
+                $table->string('contact_phone')->nullable()->after('contact_email');
+            }
+            if (! Schema::hasColumn('vendors', 'address')) {
+                $table->text('address')->nullable()->after('contact_phone');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vendors', function (Blueprint $table) {
+            $table->dropColumn(['contact_name', 'contact_email', 'contact_phone', 'address']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Adds migration for missing `contact_name`, `contact_email`, `contact_phone`, and `address` columns to the `vendors` table
- These fields are used in the VendorResource form but were never added to the database schema
- Migration safely checks if columns exist before adding them, ensuring compatibility with both new and existing databases