### PR TITLE
fix: Auto-attach implementation to control when created from relation manager

### DIFF
--- a/app/Filament/Resources/ControlResource/RelationManagers/ImplementationRelationManager.php
+++ b/app/Filament/Resources/ControlResource/RelationManagers/ImplementationRelationManager.php
@@ -54,7 +54,12 @@ class ImplementationRelationManager extends RelationManager
                 SelectFilter::make('effectiveness')->options(Effectiveness::class),
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                    ->label('New implementation')
+                    ->after(function ($record) {
+                        // Attach the newly created implementation to this control
+                        $this->getOwnerRecord()->implementations()->syncWithoutDetaching([$record->id]);
+                    }),
                 Tables\Actions\AttachAction::make()
                     ->label('Add Existing Implementation')
                     ->preloadRecordSelect()


### PR DESCRIPTION
## Summary
When creating a new implementation from the Control view page's "New implementation" button, the implementation was not being automatically attached to the control. Users had to manually select the control in the "Related Controls" dropdown.

This fix adds an `after` hook to the CreateAction that automatically attaches the newly created implementation to the current control using `syncWithoutDetaching`.