### PR TITLE
fix: Replace Faker with Str::random for password generation

### DIFF
--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -8,7 +8,6 @@ use App\Mail\UserCreatedMail;
 use App\Mail\UserForceResetMail;
 use App\Models\User;
 use Exception;
-use Faker\Factory;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
@@ -164,7 +163,8 @@ class UserResource extends Resource
 
     public static function createDefaultPassword(): string
     {
-        return Str::replace(' ', '-', implode(' ', Factory::create('en_US')->words(4)));
+        $words = collect(range(1, 4))->map(fn () => Str::random(6))->implode('-');
+        return $words;
     }
 
     public static function resetPasswordAction(User $record): void


### PR DESCRIPTION
## Summary
- Remove dependency on `Faker\Factory` in UserResource which caused "Class Faker\Factory not found" error in production
- Replace with Laravel's built-in `Str::random()` for generating temporary passwords
- Faker is a dev-only dependency and is not available in production environments