### PR TITLE
fix: Prevent information disclosure in error pages

### DIFF
--- a/app/Filament/Resources/RiskResource.php
+++ b/app/Filament/Resources/RiskResource.php
@@ -187,7 +187,6 @@ class RiskResource extends Resource
                         ->orderBy('dept_taxonomies.name', $direction)
                         ->select('risks.*');
                     })
-                    ->searchable()
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('taxonomy_scope')
                     ->label('Scope')
@@ -209,7 +208,6 @@ class RiskResource extends Resource
                         ->orderBy('scope_taxonomies.name', $direction)
                         ->select('risks.*');
                     })
-                    ->searchable()
                     ->toggleable(),
             ])
             ->filters([

--- a/resources/views/errors/401.blade.php
+++ b/resources/views/errors/401.blade.php
@@ -30,8 +30,11 @@
         <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-3xl lg:text-3xl dark:text-white text-center"
             style="font-family: 'Bruno Ace SC', sans-serif;">OpenGRC</h1>
 
+        {{-- Fixed in response to Pentest Finding --}}
         <div class="text-center mt-12">
-            <p class="bg-grcblue-400 text-white p-3 rounded ">{{ $exception->getMessage() }}</p>
+            <p class="bg-grcblue-400 text-white p-3 rounded ">
+                {{ config('app.debug') ? $exception->getMessage() : 'Access denied. Please log in to continue.' }}
+            </p>
         </div>
 
     </div>

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -30,8 +30,11 @@
         <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-3xl lg:text-3xl dark:text-white text-center"
             style="font-family: 'Bruno Ace SC', sans-serif;">OpenGRC</h1>
 
+        {{-- Fixed in response to Pentest Finding --}}
         <div class="text-center mt-12">
-            <p class="bg-grcblue-400 text-white p-3 rounded ">{{ $exception->getMessage() ?: __('Forbidden') }}</p>
+            <p class="bg-grcblue-400 text-white p-3 rounded ">
+                {{ config('app.debug') ? $exception->getMessage() : __('Forbidden') }}
+            </p>
         </div>
 
     </div>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -30,8 +30,11 @@
         <h1 class="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-3xl lg:text-3xl dark:text-white text-center"
             style="font-family: 'Bruno Ace SC', sans-serif;">OpenGRC</h1>
 
+        
         <div class="text-center mt-12">
-            <p class="bg-grcblue-400 text-white p-3 rounded ">{{ $exception->getMessage() }}</p>
+            <p class="bg-grcblue-400 text-white p-3 rounded ">
+                {{ config('app.debug') ? $exception->getMessage() : 'An unexpected error occurred. Please try again later.' }}
+            </p>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- Error pages (401, 403, 500) now only display detailed exception messages when `app.debug` is enabled
- In production, users see generic, safe error messages instead of potentially sensitive exception details
- Fixed RiskResource `searchable()` calls on taxonomy columns that were causing exceptions due to relationship-based sorting (this bug exposed the information disclosure vulnerability)

## Security
This addresses a pentest finding where sensitive error details were being exposed to end users in production environments.