### PR TITLE
fix: Handle session expiration gracefully in Livewire requests

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -94,6 +94,10 @@ class AdminPanelProvider extends PanelProvider
                 PanelsRenderHook::BODY_END,
                 fn () => Blade::render("@livewire('multi-window-inactivity-guard')")
             )
+            ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn () => view('components.session-expiration-handler')
+            )
             ->navigationItems([
                 NavigationItem::make('Back to OpenGRC')
                     ->url('/app', shouldOpenInNewTab: false)

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -134,6 +134,10 @@ class AppPanelProvider extends PanelProvider
                 PanelsRenderHook::BODY_END,
                 fn () => Blade::render("@livewire('multi-window-inactivity-guard')")
             )
+            ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn () => view('components.session-expiration-handler')
+            )
             ->navigationGroups([
                 'Foundations',
                 'Entities',

--- a/app/Providers/Filament/VendorPanelProvider.php
+++ b/app/Providers/Filament/VendorPanelProvider.php
@@ -17,6 +17,7 @@ use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Filament\View\PanelsRenderHook;
 
 class VendorPanelProvider extends PanelProvider
 {
@@ -54,7 +55,11 @@ class VendorPanelProvider extends PanelProvider
             ->authMiddleware([
                 Authenticate::class,
                 RequireVendorPassword::class,
-            ]);
+            ])
+            ->renderHook(
+                PanelsRenderHook::BODY_END,
+                fn () => view('components.session-expiration-handler')
+            );
     }
 
     private function getPortalName(): string

--- a/resources/views/components/session-expiration-handler.blade.php
+++ b/resources/views/components/session-expiration-handler.blade.php
@@ -1,0 +1,13 @@
+<script>
+    document.addEventListener('livewire:init', () => {
+        Livewire.hook('request', ({ fail }) => {
+            fail(({ status, preventDefault }) => {
+                // Session expired (CSRF token mismatch) or Unauthorized
+                if (status === 419 || status === 401) {
+                    preventDefault();
+                    window.location.reload();
+                }
+            });
+        });
+    });
+</script>


### PR DESCRIPTION
## Summary
- Adds JavaScript handler to intercept Livewire AJAX requests that return 401 (Unauthorized) or 419 (Session Expired) status codes
- Forces a full page reload instead of letting Livewire render the login page inside modals/components
- Fixes the broken UX where the login form would appear inside the current page layout after session timeout