### PR TITLE
fix: Add missing HTTP Strict-Transport-Security header

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -24,6 +24,11 @@ class SecurityHeaders
         $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
         $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
 
+        // HSTS - only in production to avoid issues with local development
+        if (app()->environment('production')) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+
         // CSP only for HTML responses
         if ($this->shouldAddCsp($response)) {
             $response->headers->set('Content-Security-Policy', $this->buildPolicy($request));


### PR DESCRIPTION
## Summary
- Adds HSTS header to `SecurityHeaders` middleware to address pentest finding
- Header only applied in production environment to avoid breaking local HTTP development
- Uses standard 1-year max-age with includeSubDomains directive