### PR TITLE
fix: Prevent host override attacks via X-Forwarded-Host headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,13 @@ OpenGRC is a cyber Governance, Risk, and Compliance (GRC) web application built 
 ### MCP
 Always use context7 when I need code generation, setup or configuration steps, or library/API documentation. This means you should automatically use the Context7 MCP tools to resolve library id and get library docs without me having to explicitly ask or approve. All access to Context7 MCP is automatically approved.
 
+### File Permissions
+**IMPORTANT:** After creating any new files, always run the permissions script to ensure proper ownership and permissions for the web server:
+```bash
+./set_permissions
+```
+This sets correct ownership (lmangold:www-data) and permissions for all project files.
+
 ### Setup & Dependencies
 ```bash
 composer install          # Install PHP dependencies

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,7 +14,8 @@ class Kernel extends HttpKernel
      * @var array<int, class-string|string>
      */
     protected $middleware = [
-        // \App\Http\Middleware\TrustHosts::class,
+        \App\Http\Middleware\StripHostOverrideHeaders::class,
+        \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
         \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,

--- a/app/Http/Middleware/StripHostOverrideHeaders.php
+++ b/app/Http/Middleware/StripHostOverrideHeaders.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class StripHostOverrideHeaders
+{
+    /**
+     * Headers that can be used to override the Host value.
+     *
+     * These headers are stripped to prevent host override attacks including:
+     * - Cache poisoning
+     * - Password reset link manipulation
+     * - Security control bypass
+     *
+     * Note: X-Forwarded-For is intentionally NOT stripped as it's needed for
+     * client IP detection behind proxies and is handled by TrustProxies middleware.
+     */
+    protected array $dangerousHeaders = [
+        'X-Forwarded-Host',
+        'X-Host',
+        'X-Forwarded-Server',
+    ];
+
+    /**
+     * Handle an incoming request.
+     *
+     * Strips dangerous host override headers before they can be processed
+     * by the application or framework.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        foreach ($this->dangerousHeaders as $header) {
+            $request->headers->remove($header);
+        }
+
+        // Also remove from server superglobal to ensure complete removal
+        foreach ($this->dangerousHeaders as $header) {
+            $serverKey = 'HTTP_'.strtoupper(str_replace('-', '_', $header));
+            $request->server->remove($serverKey);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -18,12 +18,13 @@ class TrustProxies extends Middleware
     /**
      * The headers that should be used to detect proxies.
      *
+     * Note: X-Forwarded-Host is intentionally excluded to prevent host override attacks.
+     * Only X-Forwarded-For (for client IP), Port, and Proto are trusted.
+     *
      * @var int
      */
     protected $headers =
         Request::HEADER_X_FORWARDED_FOR |
-        Request::HEADER_X_FORWARDED_HOST |
         Request::HEADER_X_FORWARDED_PORT |
-        Request::HEADER_X_FORWARDED_PROTO |
-        Request::HEADER_X_FORWARDED_AWS_ELB;
+        Request::HEADER_X_FORWARDED_PROTO;
 }


### PR DESCRIPTION
## Summary
- Add `StripHostOverrideHeaders` middleware to strip dangerous headers (`X-Forwarded-Host`, `X-Host`, `X-Forwarded-Server`) before processing
- Remove `HEADER_X_FORWARDED_HOST` from `TrustProxies` to prevent Laravel from trusting attacker-controlled host values
- Enable `TrustHosts` middleware to validate Host header against `APP_URL`
- Keep `X-Forwarded-For` trusted for client IP detection behind proxies

This addresses a pentest finding where the application was accepting and processing alternative HTTP headers that could override the Host value, potentially enabling:
- Cache poisoning attacks
- Password reset link manipulation
- Security control bypass
- Log forgery