### PR TITLE
fix: Prevent sensitive credentials from appearing in browser DOM

### DIFF
--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -474,7 +474,7 @@ class Deploy extends Command
         ];
 
         // Only update site name for fresh deployments
-        if (!$isUpdate) {
+        if (! $isUpdate) {
             $envData['APP_NAME'] = $config['site_name'];
         }
 
@@ -542,7 +542,7 @@ class Deploy extends Command
             $this->info('[SUCCESS] Database migrations completed');
 
             // Skip user creation and role seeding for updates, but ensure settings are initialized
-            if (!$isUpdate) {
+            if (! $isUpdate) {
                 // Create admin user
                 $this->info('[INFO] Creating admin user...');
                 $this->call('opengrc:create-user', [
@@ -570,7 +570,7 @@ class Deploy extends Command
         $this->info('[INFO] Configuring site settings...');
 
         // Only update site name for fresh deployments
-        if (!$isUpdate) {
+        if (! $isUpdate) {
             $this->call('settings:set', [
                 'key' => 'general.name',
                 'value' => $config['site_name'],
@@ -650,7 +650,7 @@ class Deploy extends Command
             ]);
             $this->call('settings:set', [
                 'key' => 'mail.password',
-                'value' => $config['smtp_password'],
+                'value' => Crypt::encryptString($config['smtp_password']),
             ]);
             $this->call('settings:set', [
                 'key' => 'mail.encryption',
@@ -699,9 +699,9 @@ class Deploy extends Command
 
         // Set production permissions (skip in containerized environments)
         // Detect container environment: no node_modules means pre-built Docker image
-        $isContainer = !file_exists(base_path('node_modules'));
+        $isContainer = ! file_exists(base_path('node_modules'));
 
-        if (PHP_OS === 'Linux' && !$isContainer) {
+        if (PHP_OS === 'Linux' && ! $isContainer) {
             $this->info('[INFO] Setting file permissions...');
 
             // Check if set_permissions script exists and run it

--- a/app/Filament/Admin/Pages/Settings/AuthenticationSettings.php
+++ b/app/Filament/Admin/Pages/Settings/AuthenticationSettings.php
@@ -2,15 +2,13 @@
 
 namespace App\Filament\Admin\Pages\Settings;
 
-use App\Filament\Admin\Pages\Settings\Schemas\AuthenticationSchema;
 use Closure;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Grid;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Illuminate\Support\Facades\Crypt;
 use Spatie\Permission\Models\Role;
 
@@ -62,11 +60,19 @@ class AuthenticationSettings extends BaseSettings
                                 ->password()
                                 ->visible(fn ($get) => $get('auth.azure.enabled'))
                                 ->required(fn ($get) => $get('auth.azure.enabled'))
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        $component->state(Crypt::decryptString($state));
+                                ->placeholder(fn () => filled(setting('auth.azure.client_secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('auth.azure.client_secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('auth.azure.client_secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
                             TextInput::make('auth.azure.tenant')
                                 ->label('Tenant')
@@ -110,11 +116,19 @@ class AuthenticationSettings extends BaseSettings
                                 ->password()
                                 ->visible(fn ($get) => $get('auth.okta.enabled'))
                                 ->required(fn ($get) => $get('auth.okta.enabled'))
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        $component->state(Crypt::decryptString($state));
+                                ->placeholder(fn () => filled(setting('auth.okta.client_secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('auth.okta.client_secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('auth.okta.client_secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
                             TextInput::make('auth.okta.base_url')
                                 ->label('Base URL')
@@ -157,11 +171,19 @@ class AuthenticationSettings extends BaseSettings
                                 ->password()
                                 ->visible(fn ($get) => $get('auth.google.enabled'))
                                 ->required(fn ($get) => $get('auth.google.enabled'))
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        $component->state(Crypt::decryptString($state));
+                                ->placeholder(fn () => filled(setting('auth.google.client_secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('auth.google.client_secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('auth.google.client_secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
                             Placeholder::make('auth.google.redirect')
                                 ->label('Redirect URL')
@@ -200,11 +222,19 @@ class AuthenticationSettings extends BaseSettings
                                 ->password()
                                 ->visible(fn ($get) => $get('auth.auth0.enabled'))
                                 ->required(fn ($get) => $get('auth.auth0.enabled'))
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        $component->state(Crypt::decryptString($state));
+                                ->placeholder(fn () => filled(setting('auth.auth0.client_secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('auth.auth0.client_secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('auth.auth0.client_secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
                             TextInput::make('auth.auth0.domain')
                                 ->label('Domain')

--- a/app/Filament/Admin/Pages/Settings/BaseSettings.php
+++ b/app/Filament/Admin/Pages/Settings/BaseSettings.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Filament\Admin\Pages\Settings;
+
+use Outerweb\FilamentSettings\Filament\Pages\Settings as PackageSettings;
+use Outerweb\Settings\Models\Setting;
+
+/**
+ * Base settings class that filters sensitive data from the Livewire payload.
+ *
+ * All settings pages should extend this class instead of the package's Settings class
+ * to ensure sensitive credentials are not exposed in the browser DOM.
+ */
+abstract class BaseSettings extends PackageSettings
+{
+    /**
+     * Override fillForm to exclude sensitive data from initial data load.
+     * This prevents encrypted credentials from appearing in the Livewire payload.
+     */
+    protected function fillForm(): void
+    {
+        $data = Setting::get();
+
+        // Remove sensitive credentials from the data
+        // These fields use placeholder patterns and only update when new values are entered
+        $this->removeSensitiveData($data);
+
+        $this->callHook('beforeFill');
+
+        $this->form->fill($data);
+
+        $this->callHook('afterFill');
+    }
+
+    /**
+     * Remove sensitive data from the settings array.
+     * Override this method to add additional sensitive fields.
+     */
+    protected function removeSensitiveData(array &$data): void
+    {
+        // Mail password - encrypted and should never be sent to browser
+        if (isset($data['mail']['password'])) {
+            unset($data['mail']['password']);
+        }
+
+        // AI OpenAI API key - encrypted and should never be sent to browser
+        if (isset($data['ai']['openai_key'])) {
+            unset($data['ai']['openai_key']);
+        }
+
+        // Storage credentials - encrypted and should never be sent to browser
+        // S3 credentials
+        if (isset($data['storage']['s3']['key'])) {
+            unset($data['storage']['s3']['key']);
+        }
+        if (isset($data['storage']['s3']['secret'])) {
+            unset($data['storage']['s3']['secret']);
+        }
+
+        // DigitalOcean Spaces credentials
+        if (isset($data['storage']['digitalocean']['key'])) {
+            unset($data['storage']['digitalocean']['key']);
+        }
+        if (isset($data['storage']['digitalocean']['secret'])) {
+            unset($data['storage']['digitalocean']['secret']);
+        }
+
+        // SSO client secrets - encrypted and should never be sent to browser
+        if (isset($data['auth']['azure']['client_secret'])) {
+            unset($data['auth']['azure']['client_secret']);
+        }
+        if (isset($data['auth']['okta']['client_secret'])) {
+            unset($data['auth']['okta']['client_secret']);
+        }
+        if (isset($data['auth']['google']['client_secret'])) {
+            unset($data['auth']['google']['client_secret']);
+        }
+        if (isset($data['auth']['auth0']['client_secret'])) {
+            unset($data['auth']['auth0']['client_secret']);
+        }
+    }
+}

--- a/app/Filament/Admin/Pages/Settings/MailSettings.php
+++ b/app/Filament/Admin/Pages/Settings/MailSettings.php
@@ -5,7 +5,6 @@ namespace App\Filament\Admin\Pages\Settings;
 use App\Filament\Admin\Pages\Settings\Schemas\MailSchema;
 use Closure;
 use Filament\Forms\Components\Section;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 
 class MailSettings extends BaseSettings
 {
@@ -17,7 +16,7 @@ class MailSettings extends BaseSettings
 
     public static function canAccess(): bool
     {
-        if (auth()->check() && auth()->user()->can('Manage Preferences') && setting('storage.locked') != "true") {
+        if (auth()->check() && auth()->user()->can('Manage Preferences') && setting('storage.locked') != 'true') {
             return true;
         }
 

--- a/app/Filament/Admin/Pages/Settings/MailTemplateSettings.php
+++ b/app/Filament/Admin/Pages/Settings/MailTemplateSettings.php
@@ -5,7 +5,6 @@ namespace App\Filament\Admin\Pages\Settings;
 use App\Filament\Admin\Pages\Settings\Schemas\MailTemplatesSchema;
 use Closure;
 use Filament\Forms\Components\Tabs;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 
 class MailTemplateSettings extends BaseSettings
 {

--- a/app/Filament/Admin/Pages/Settings/ReportSettings.php
+++ b/app/Filament/Admin/Pages/Settings/ReportSettings.php
@@ -2,9 +2,7 @@
 
 namespace App\Filament\Admin\Pages\Settings;
 
-use App\Filament\Admin\Pages\Settings\Schemas\ReportSchema;
 use Closure;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Section;
 use Illuminate\Support\Facades\Storage;

--- a/app/Filament/Admin/Pages/Settings/SecuritySettings.php
+++ b/app/Filament/Admin/Pages/Settings/SecuritySettings.php
@@ -2,11 +2,9 @@
 
 namespace App\Filament\Admin\Pages\Settings;
 
-use App\Filament\Admin\Pages\Settings\Schemas\SecuritySchema;
 use Closure;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
-use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
 
 class SecuritySettings extends BaseSettings
 {

--- a/app/Filament/Admin/Pages/Settings/Settings.php
+++ b/app/Filament/Admin/Pages/Settings/Settings.php
@@ -2,10 +2,7 @@
 
 namespace App\Filament\Admin\Pages\Settings;
 
-use App\Filament\Admin\Pages\Settings\Schemas\GeneralSchema;
 use Closure;
-use Filament\Forms\Components\Tabs;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 
@@ -61,5 +58,4 @@ class Settings extends BaseSettings
                 ]),
         ];
     }
-
 }

--- a/app/Filament/Admin/Pages/Settings/StorageSettings.php
+++ b/app/Filament/Admin/Pages/Settings/StorageSettings.php
@@ -12,7 +12,6 @@ use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 use Throwable;
 
 class StorageSettings extends BaseSettings
@@ -76,19 +75,24 @@ class StorageSettings extends BaseSettings
                         ->schema([
                             TextInput::make('storage.s3.key')
                                 ->label('AWS Access Key ID')
+                                ->password()
                                 ->visible(fn ($get) => $get('storage.driver') === 's3')
                                 ->required(fn ($get) => $get('storage.driver') === 's3')
                                 ->dehydrated(fn ($get) => $get('storage.driver') === 's3')
                                 ->disabled($isLocked)
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        try {
-                                            $component->state(Crypt::decryptString($state));
-                                        } catch (\Exception $e) {
-                                            $component->state('');
-                                        }
+                                ->placeholder(fn () => filled(setting('storage.s3.key')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('storage.s3.key'))
+                                    ? 'Key is stored securely. Leave blank to keep current key.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('storage.s3.key');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
 
                             TextInput::make('storage.s3.secret')
@@ -98,15 +102,19 @@ class StorageSettings extends BaseSettings
                                 ->required(fn ($get) => $get('storage.driver') === 's3')
                                 ->dehydrated(fn ($get) => $get('storage.driver') === 's3')
                                 ->disabled($isLocked)
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        try {
-                                            $component->state(Crypt::decryptString($state));
-                                        } catch (\Exception $e) {
-                                            $component->state('');
-                                        }
+                                ->placeholder(fn () => filled(setting('storage.s3.secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('storage.s3.secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : null)
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('storage.s3.secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
 
                             TextInput::make('storage.s3.region')
@@ -126,39 +134,46 @@ class StorageSettings extends BaseSettings
 
                             TextInput::make('storage.digitalocean.key')
                                 ->label('DigitalOcean Spaces Access Key ID')
-                                ->helperText('Your DigitalOcean Spaces access key ID')
+                                ->password()
                                 ->visible(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->required(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->dehydrated(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->disabled($isLocked)
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        try {
-                                            $component->state(Crypt::decryptString($state));
-                                        } catch (\Exception $e) {
-                                            $component->state('');
-                                        }
+                                ->placeholder(fn () => filled(setting('storage.digitalocean.key')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('storage.digitalocean.key'))
+                                    ? 'Key is stored securely. Leave blank to keep current key.'
+                                    : 'Your DigitalOcean Spaces access key ID')
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('storage.digitalocean.key');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
 
                             TextInput::make('storage.digitalocean.secret')
                                 ->label('DigitalOcean Spaces Secret Access Key')
                                 ->password()
-                                ->helperText('Your DigitalOcean Spaces secret access key')
                                 ->visible(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->required(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->dehydrated(fn ($get) => $get('storage.driver') === 'digitalocean')
                                 ->disabled($isLocked)
-                                ->dehydrateStateUsing(fn ($state) => filled($state) ? Crypt::encryptString($state) : null)
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    if (filled($state)) {
-                                        try {
-                                            $component->state(Crypt::decryptString($state));
-                                        } catch (\Exception $e) {
-                                            $component->state('');
-                                        }
+                                ->placeholder(fn () => filled(setting('storage.digitalocean.secret')) ? '••••••••' : null)
+                                ->helperText(fn () => filled(setting('storage.digitalocean.secret'))
+                                    ? 'Secret is stored securely. Leave blank to keep current secret.'
+                                    : 'Your DigitalOcean Spaces secret access key')
+                                ->dehydrateStateUsing(function ($state) {
+                                    if (! filled($state)) {
+                                        return setting('storage.digitalocean.secret');
                                     }
+
+                                    return Crypt::encryptString($state);
+                                })
+                                ->afterStateHydrated(function (TextInput $component, $state) {
+                                    $component->state(null);
                                 }),
 
                             TextInput::make('storage.digitalocean.region')

--- a/app/Filament/Admin/Pages/Settings/TrustCenterSettings.php
+++ b/app/Filament/Admin/Pages/Settings/TrustCenterSettings.php
@@ -6,7 +6,6 @@ use App\Filament\Admin\Pages\Settings\Schemas\TrustCenterMailSchema;
 use App\Filament\Admin\Pages\Settings\Schemas\TrustCenterNdaSchema;
 use Closure;
 use Filament\Forms\Components\Tabs;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 
 class TrustCenterSettings extends BaseSettings
 {

--- a/app/Filament/Admin/Pages/Settings/VendorPortalSettings.php
+++ b/app/Filament/Admin/Pages/Settings/VendorPortalSettings.php
@@ -8,7 +8,6 @@ use App\Filament\Admin\Pages\Settings\Schemas\VendorPortalMailSchema;
 use App\Filament\Admin\Pages\Settings\Schemas\VendorPortalSchema;
 use Closure;
 use Filament\Forms\Components\Tabs;
-use Outerweb\FilamentSettings\Filament\Pages\Settings as BaseSettings;
 
 class VendorPortalSettings extends BaseSettings
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -59,12 +59,22 @@ class AppServiceProvider extends ServiceProvider
                 Config::set('app.name', setting('general.name', 'OpenGRC'));
                 Config::set('app.url', setting('general.url', 'https://opengrc.test'));
 
+                // Decrypt mail password if it's encrypted
+                $mailPassword = setting('mail.password');
+                if (! empty($mailPassword)) {
+                    try {
+                        $mailPassword = Crypt::decryptString($mailPassword);
+                    } catch (\Exception $e) {
+                        // If decryption fails, assume it's plaintext (legacy data)
+                    }
+                }
+
                 config()->set('mail', array_merge(config('mail'), [
                     'driver' => 'smtp',
                     'transport' => 'smtp',
                     'host' => setting('mail.host'),
                     'username' => setting('mail.username'),
-                    'password' => setting('mail.password'),
+                    'password' => $mailPassword,
                     'encryption' => setting('mail.encryption'),
                     'port' => setting('mail.port'),
                     'from' => [

--- a/database/migrations/2026_01_01_011827_encrypt_existing_mail_passwords.php
+++ b/database/migrations/2026_01_01_011827_encrypt_existing_mail_passwords.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * This migration encrypts any existing plaintext mail.password values
+     * in the settings table to address security vulnerability where
+     * SMTP credentials were stored unencrypted.
+     */
+    public function up(): void
+    {
+        // Get the current mail.password setting
+        $setting = DB::table('settings')
+            ->where('key', 'mail.password')
+            ->first();
+
+        if (! $setting || empty($setting->value)) {
+            return;
+        }
+
+        // The value is stored as JSON, so decode it
+        $password = json_decode($setting->value, true);
+
+        if (empty($password)) {
+            return;
+        }
+
+        // Check if the password is already encrypted by attempting to decrypt it
+        try {
+            Crypt::decryptString($password);
+            // If decryption succeeds, it's already encrypted - nothing to do
+            Log::info('Mail password is already encrypted, skipping migration.');
+
+            return;
+        } catch (\Exception $e) {
+            // Decryption failed, so the password is plaintext and needs encryption
+        }
+
+        // Encrypt the plaintext password
+        $encryptedPassword = Crypt::encryptString($password);
+
+        // Update the setting with the encrypted value
+        DB::table('settings')
+            ->where('key', 'mail.password')
+            ->update(['value' => json_encode($encryptedPassword)]);
+
+        Log::info('Mail password has been encrypted successfully.');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Note: We cannot reverse this migration as we cannot decrypt
+     * the password without knowing the original plaintext value.
+     * This is intentional for security reasons.
+     */
+    public function down(): void
+    {
+        // Cannot reverse encryption - this is intentional for security
+        Log::warning('Cannot reverse mail password encryption migration. This is intentional for security.');
+    }
+};


### PR DESCRIPTION
## Summary
- Addresses pentest finding where SMTP, storage, SSO, and API credentials were visible in the Livewire payload in the browser DOM
- Creates BaseSettings class that filters sensitive data before form hydration
- Implements placeholder pattern for credential fields (never display actual values, show "leave blank to keep current")
- Adds migration to encrypt existing plaintext mail passwords

## Affected Credentials
- Mail/SMTP password
- OpenAI API key
- S3 access key and secret
- DigitalOcean Spaces key and secret
- Azure, Okta, Google, Auth0 client secrets

