### PR TITLE
Improve Role Permission Matrix table UI and dark mode support

### DIFF
--- a/resources/views/filament/pages/role-permission-matrix-table.blade.php
+++ b/resources/views/filament/pages/role-permission-matrix-table.blade.php
@@ -1,29 +1,29 @@
-<div class="overflow-x-auto bg-white rounded-xl border border-gray-200">
+<div class="overflow-auto max-h-[70vh] bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700">
     <table class="role-permission-matrix w-full">
-        <thead>
-            <tr class="bg-gray-50">
-                <th class="px-4 py-2 text-left">Permissions</th>
+        <thead class="sticky top-0 z-10">
+            <tr class="bg-gray-50 dark:bg-gray-800">
+                <th class="px-4 py-2 text-left bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100">Permissions</th>
                 @foreach($getRoles() as $role)
-                    <th class="px-4 py-2 text-center">{{ $role->name }}</th>
+                    <th class="px-4 py-2 text-center bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100">{{ $role->name }}</th>
                 @endforeach
             </tr>
         </thead>
         <tbody>
             @foreach($getGroupedPermissions() as $category => $permissions)
-                <tr class="border-t border-gray-200 bg-gray-50">
-                    <td class="px-4 py-2 text-left font-bold text-gray-900" colspan="{{ count($getRoles()) + 1 }}">
-                        {{ $category ? \Illuminate\Support\Str::title($category) : 'Uncategorized' }}
+                <tr class="border-t border-gray-200 dark:border-gray-700 bg-gray-200 dark:bg-gray-600">
+                    <td class="px-4 py-2 text-left font-bold text-gray-900 dark:text-gray-100" colspan="{{ count($getRoles()) + 1 }}">
+                        {{ $category ? \Illuminate\Support\Str::headline($category) : 'Uncategorized' }}
                     </td>
                 </tr>
                 @foreach($permissions as $permission)
-                    <tr class="border-t border-gray-100">
-                        <td class="px-4 py-2 text-left pl-8">{{ $permission->name }}</td>
+                    <tr class="border-t border-gray-100 dark:border-gray-700">
+                        <td class="px-4 py-2 text-left pl-8 text-gray-700 dark:text-gray-300">{{ $permission->name }}</td>
                         @foreach($getRoles() as $role)
                             <td class="px-4 py-2 text-center">
                                 <label class="inline-flex items-center justify-center">
-                                    <input 
+                                    <input
                                         type="checkbox"
-                                        class="text-primary-600 transition duration-75 rounded shadow-sm focus:border-primary-500 focus:ring-2 focus:ring-primary-500 disabled:opacity-70 border-gray-300"
+                                        class="text-green-600 dark:text-green-400 transition duration-75 rounded shadow-sm focus:border-green-500 focus:ring-2 focus:ring-green-500 dark:focus:ring-green-400 disabled:opacity-70 border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:checked:bg-green-800"
                                         @if($role->hasPermissionTo($permission)) checked @endif
                                         wire:click="togglePermission({{ $role->id }}, {{ $permission->id }})"
                                     >
@@ -35,4 +35,4 @@
             @endforeach
         </tbody>
     </table>
-</div> 
+</div>


### PR DESCRIPTION
## Summary
- Add sticky header that remains visible when scrolling the permissions table
- Add full dark mode support with appropriate color variants for all elements
- Change checkbox color from orange (primary) to green for better visual feedback
- Use `Str::headline()` for proper category name formatting (e.g., "DataRequestResponses" → "Data Request Responses")
- Darken category header rows for better visual separation between permission groups
- Set max-height (70vh) with overflow for better page layout on long permission lists