### PR TITLE
Fix Docker build and add first-run setup with docker-compose

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,6 +43,20 @@ class AppServiceProvider extends ServiceProvider
             || $argv[1] === 'filament:upgrade'
             || $argv[1] === 'vendor:publish'
             || $argv[1] === 'test'
+            || $argv[1] === 'migrate'
+            || str_starts_with($argv[1], 'migrate:')
+            || $argv[1] === 'config:cache'
+            || $argv[1] === 'config:clear'
+            || $argv[1] === 'route:cache'
+            || $argv[1] === 'route:clear'
+            || $argv[1] === 'view:cache'
+            || $argv[1] === 'view:clear'
+            || $argv[1] === 'cache:clear'
+            || $argv[1] === 'key:generate'
+            || $argv[1] === 'storage:link'
+            || $argv[1] === 'db:seed'
+            || $argv[1] === 'opengrc:create-user'
+            || $argv[1] === 'settings:set'
             )) {
                 $isInstaller = true;
             }

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,6 @@
         {
             "type": "vcs",
             "url": "https://github.com/MangoldSecurity/filament-settings"
-        },
-        {
-            "type": "path",
-            "url": "/home/lmangold/projects/OGModules/WorkflowModule"
         }
     ],
     "require": {
@@ -51,7 +47,6 @@
         "socialiteproviders/google": "^4.1",
         "socialiteproviders/microsoft-azure": "^5.2",
         "socialiteproviders/okta": "^4.5",
-        "opengrc/workflow-module": "@dev",
         "spatie/laravel-permission": "^6.24.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -6559,41 +6559,6 @@
             "time": "2025-02-18T09:58:04+00:00"
         },
         {
-            "name": "opengrc/workflow-module",
-            "version": "dev-main",
-            "dist": {
-                "type": "path",
-                "url": "/home/lmangold/projects/OGModules/WorkflowModule",
-                "reference": "3db9c9c4aa12fef8bc7fc0dd73bd889917f44b04"
-            },
-            "require": {
-                "filament/filament": "^4.0",
-                "illuminate/support": "^11.0|^12.0",
-                "livewire/livewire": "^3.0",
-                "php": "^8.2"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "OpenGrc\\WorkflowModule\\Providers\\WorkflowModuleServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "OpenGrc\\WorkflowModule\\": "src/"
-                }
-            },
-            "license": [
-                "proprietary"
-            ],
-            "description": "Workflow engine module for OpenGRC",
-            "transport-options": {
-                "relative": false
-            }
-        },
-        {
             "name": "openspout/openspout",
             "version": "v4.32.0",
             "source": {
@@ -17709,9 +17674,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "opengrc/workflow-module": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: opengrc
+      MYSQL_USER: opengrc_user
+      MYSQL_PASSWORD: opengrc_password
+    volumes:
+      - opengrc_db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  app:
+    image: opengrc
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    environment:
+      APP_NAME: OpenGRC
+      APP_ENV: local
+      APP_DEBUG: "true"
+      APP_KEY: base64:kR3VG+FmVBNmFqt6Y1INBwK5r4dLK+S7RP7hGGn1JQo=
+      APP_URL: http://localhost:8080
+
+      DB_CONNECTION: mysql
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_DATABASE: opengrc
+      DB_USERNAME: opengrc_user
+      DB_PASSWORD: opengrc_password
+
+      ADMIN_EMAIL: admin@opengrc.local
+      ADMIN_PASSWORD: admin123
+
+      CACHE_DRIVER: file
+      SESSION_DRIVER: file
+      QUEUE_CONNECTION: sync
+
+      MAIL_MAILER: log
+
+volumes:
+  opengrc_db:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,15 @@ if [ -n "$DB_HOST" ]; then
     max_attempts=30
     attempt=0
     while [ $attempt -lt $max_attempts ]; do
-        if php artisan tinker --execute="try { DB::connection()->getPdo(); echo 'ok'; } catch (\Exception \$e) { exit(1); }" 2>/dev/null | grep -q "ok"; then
+        if php -r "
+            try {
+                \$dsn = 'mysql:host=' . getenv('DB_HOST') . ';port=' . (getenv('DB_PORT') ?: 3306) . ';dbname=' . getenv('DB_DATABASE');
+                new PDO(\$dsn, getenv('DB_USERNAME'), getenv('DB_PASSWORD'));
+                echo 'ok';
+            } catch (Exception \$e) {
+                exit(1);
+            }
+        " 2>/dev/null | grep -q "ok"; then
             echo "Database connected."
             break
         fi
@@ -25,6 +33,24 @@ fi
 # Run database migrations
 echo "Running database migrations..."
 php artisan migrate --force
+
+# Seed and create admin user only on first run (check if users table is empty)
+USER_COUNT=$(php -r "
+    \$dsn = 'mysql:host=' . getenv('DB_HOST') . ';port=' . (getenv('DB_PORT') ?: 3306) . ';dbname=' . getenv('DB_DATABASE');
+    \$pdo = new PDO(\$dsn, getenv('DB_USERNAME'), getenv('DB_PASSWORD'));
+    echo \$pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+" 2>/dev/null || echo "0")
+
+if [ "$USER_COUNT" = "0" ]; then
+    echo "First run detected - seeding database and creating admin user..."
+    php artisan db:seed --class=SettingsSeeder --force
+    php artisan opengrc:create-user "${ADMIN_EMAIL:-admin@opengrc.local}" "${ADMIN_PASSWORD:-admin123}"
+    php artisan db:seed --class=RolePermissionSeeder --force
+    php artisan settings:set general.name "${APP_NAME:-OpenGRC}"
+    php artisan settings:set general.url "${APP_URL:-http://localhost}"
+    php artisan settings:set storage.driver private
+    php artisan storage:link
+fi
 
 # Clear and cache config for production
 echo "Caching configuration..."


### PR DESCRIPTION
## Summary

This PR fixes several issues that prevented OpenGRC from building and running correctly with Docker, and adds a ready-to-use `docker-compose.yml` for local development.

## Changes

### Fix Docker build — remove local path dependency (`composer.json`)
Removes a developer-specific path repository pointing to `/home/lmangold/projects/OGModules/WorkflowModule` that caused `composer install` to fail in Docker builds with:
```
Source path not found for package opengrc/workflow-module
```

### Fix Docker container startup (`docker-entrypoint.sh`, `AppServiceProvider.php`)
Two issues prevented the container from starting correctly after `docker compose up`:

1. `docker-entrypoint.sh` used `php artisan tinker` to check DB connectivity. This triggers `AppServiceProvider::boot()` before migrations have run, aborting with _"OpenGRC was not installed properly"_ because the settings table does not yet exist. Replaced with a direct PHP PDO check that bypasses the Laravel stack.

2. `AppServiceProvider::boot()` did not include artisan commands run during container initialisation (`migrate`, `config:cache`, `route:cache`, `view:cache`, `db:seed`, `opengrc:create-user`, `settings:set`, `storage:link`) in the installer bypass list, causing all of those commands to abort. Added the missing commands so the settings-table guard is skipped during init.

### Add first-run database seeding (`docker-entrypoint.sh`)
Adds a first-run detection block that seeds the database and creates the admin user (using `ADMIN_EMAIL` / `ADMIN_PASSWORD` environment variables) when the users table is empty on startup.

### Add `docker-compose.yml` for local development
Provides a ready-to-use Docker Compose configuration:
- `db`: MySQL 8.0 with health check and named persistent volume
- `app`: OpenGRC on port 8080, waits for db to be healthy

**Usage:**
```bash
docker build -t opengrc .
docker compose up -d
```

## Testing
- Verified Docker build completes without errors
- Verified `docker compose up -d` starts both services and performs first-run seeding
- Updated `McpEndpointTest` and `StandardControlImplementationTest` to reflect current behaviour
