### PR TITLE
Reskin OpenGRC for FCC broadcast compliance

### DIFF
--- a/app/Console/Commands/FccImportAsrCommand.php
+++ b/app/Console/Commands/FccImportAsrCommand.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FccAsrRegistration;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use ZipArchive;
+
+/**
+ * Bulk-import every Antenna Structure Registration (ASR) from the FCC's
+ * Universal Licensing System (ULS) public data files.
+ *
+ * Source:
+ *   https://data.fcc.gov/download/pub/uls/complete/r_tower.zip   (~1 MB)
+ *   https://data.fcc.gov/download/pub/uls/complete/a_tower.zip   (~1 MB)
+ *
+ * Each .zip unpacks to several pipe-delimited .dat files. The key tables
+ * for ASRs:
+ *   RA.dat — Registration record (asrn, file_number, registration_action)
+ *   EN.dat — Entity (registrant_name, address)
+ *   CO.dat — Coordinates (lat/lon, height)
+ *
+ * ULS file column docs: https://www.fcc.gov/sites/default/files/pa_ddef.pdf
+ */
+class FccImportAsrCommand extends Command
+{
+    protected $signature = 'fcc:import-asr
+                            {--limit= : Cap the number of ASRs imported (smoke test)}
+                            {--skip-download : Reuse cached zip in storage/app/uls/}';
+
+    protected $description = 'Bulk-import every Antenna Structure Registration (ASR) from FCC ULS';
+
+    private const ULS_BASE = 'https://data.fcc.gov/download/pub/uls/complete/';
+
+    public function handle(): int
+    {
+        $cacheDir = storage_path('app/uls');
+        if (! is_dir($cacheDir)) mkdir($cacheDir, 0755, true);
+
+        $this->info('FCC ULS bulk import — Antenna Structure Registrations');
+        $this->newLine();
+
+        $files = ['r_tower.zip', 'a_tower.zip'];
+        foreach ($files as $f) {
+            $local = "{$cacheDir}/{$f}";
+            if (! $this->option('skip-download') || ! file_exists($local)) {
+                $this->info("Downloading {$f}…");
+                if (! $this->download(self::ULS_BASE.$f, $local)) {
+                    $this->warn("  failed: {$f} (continuing)");
+                    continue;
+                }
+                $this->line('  '.number_format(filesize($local) / 1024, 1).' KB');
+            } else {
+                $this->line("Cached: {$f}");
+            }
+            // Unzip
+            $zip = new ZipArchive;
+            if ($zip->open($local) === true) {
+                $zip->extractTo($cacheDir);
+                $zip->close();
+            }
+        }
+        $this->newLine();
+
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+
+        // Index entities (registrant names) for owner lookup
+        $this->info('Indexing entities (EN.dat)…');
+        $entities = $this->indexEntities("{$cacheDir}/EN.dat");
+        $this->line('  '.count($entities).' entities indexed');
+
+        // Index coordinates (CO.dat) for ASR location lookup
+        $this->info('Indexing coordinates (CO.dat)…');
+        $coords = $this->indexCoordinates("{$cacheDir}/CO.dat");
+        $this->line('  '.count($coords).' coordinates indexed');
+
+        // Stream RA.dat → upsert ASR records
+        $this->info('Importing ASR registrations (RA.dat)…');
+        $count = $this->importRa("{$cacheDir}/RA.dat", $entities, $coords, $limit);
+        $this->line("  {$count} ASRs imported");
+        $this->newLine();
+
+        $this->info('Done.');
+        return self::SUCCESS;
+    }
+
+    /**
+     * Build unique_system_id → entity_name mapping from EN.dat.
+     * EN.dat columns (typical ULS): record_type|unique_system_id|uls_file_num|
+     *   ebf_number|call_sign|entity_type|licensee_id|entity_name|first_name|...
+     */
+    private function indexEntities(string $path): array
+    {
+        $map = [];
+        if (! file_exists($path)) return $map;
+
+        $fh = fopen($path, 'r');
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 8) continue;
+            $sysId = trim($cols[1]);
+            $name  = trim($cols[7]);
+            if ($sysId !== '' && $name !== '') {
+                $map[$sysId] = $name;
+            }
+        }
+        fclose($fh);
+        return $map;
+    }
+
+    /**
+     * Build unique_system_id → ['lat'=>..., 'lon'=>..., 'height_m'=>...] from CO.dat.
+     * CO.dat columns: record_type|unique_system_id|uls_file_num|callsign|
+     *   loc_action|loc_type|loc_class|loc_seqid|loc_name|loc_addr|loc_city|
+     *   loc_county|loc_state|radius_op|loc_zip|...|lat_deg|lat_min|lat_sec|
+     *   lat_dir|lon_deg|lon_min|lon_sec|lon_dir|max_height_m|...
+     */
+    private function indexCoordinates(string $path): array
+    {
+        $map = [];
+        if (! file_exists($path)) return $map;
+
+        $fh = fopen($path, 'r');
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 30) continue;
+
+            $sysId = trim($cols[1]);
+            // Approximate column positions; ULS format is documented at
+            // https://www.fcc.gov/sites/default/files/pa_ddef.pdf
+            $latDeg = (float) ($cols[19] ?? 0);
+            $latMin = (float) ($cols[20] ?? 0);
+            $latSec = (float) ($cols[21] ?? 0);
+            $latDir = trim($cols[22] ?? '');
+            $lonDeg = (float) ($cols[23] ?? 0);
+            $lonMin = (float) ($cols[24] ?? 0);
+            $lonSec = (float) ($cols[25] ?? 0);
+            $lonDir = trim($cols[26] ?? '');
+            $heightM = (float) ($cols[28] ?? 0);
+
+            $lat = $this->dms($latDir, $latDeg, $latMin, $latSec);
+            $lon = $this->dms($lonDir, $lonDeg, $lonMin, $lonSec);
+
+            if ($lat !== null || $lon !== null || $heightM > 0) {
+                $map[$sysId] = ['lat' => $lat, 'lon' => $lon, 'height_m' => $heightM ?: null];
+            }
+        }
+        fclose($fh);
+        return $map;
+    }
+
+    /**
+     * Stream RA.dat → upsert into fcc_asr_registrations.
+     * RA.dat columns: record_type|content_indicator|file_number|
+     *   registration_number|unique_system_identifier|application_purpose|
+     *   previous_purpose|input_source_code|status_code|date_entered|
+     *   date_received|date_issued|date_constructed|date_dismantled|
+     *   date_action|...|height_of_structure|ground_elevation|overall_height|
+     *   structure_type|...
+     */
+    private function importRa(string $path, array $entities, array $coords, ?int $limit): int
+    {
+        if (! file_exists($path)) {
+            $this->warn('  RA.dat not found');
+            return 0;
+        }
+
+        $now = now();
+        $count = 0;
+        $batch = [];
+
+        $fh = fopen($path, 'r');
+        $progress = $this->output->createProgressBar();
+        $progress->setFormat(' %current% ASRs [%bar%] %elapsed:6s%');
+        $progress->start();
+
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 20) continue;
+
+            $sysId    = trim($cols[4] ?? '');
+            $asrNum   = trim($cols[3] ?? '');
+            $fileNum  = trim($cols[2] ?? '');
+            $statusCd = trim($cols[8] ?? '');
+
+            if ($asrNum === '' || ! ctype_digit($asrNum)) continue;
+            if ($limit !== null && $count >= $limit) break;
+
+            $owner = $entities[$sysId] ?? null;
+            $coord = $coords[$sysId] ?? ['lat' => null, 'lon' => null, 'height_m' => null];
+
+            $structureType = $this->mapStructureType($cols[34] ?? '');
+
+            $batch[$asrNum] = [
+                'asr_number'              => $asrNum,
+                'owner'                   => $owner ?: 'Unknown',
+                'structure_type'          => $structureType,
+                'overall_height_meters'   => $coord['height_m'],
+                'latitude'                => $coord['lat'],
+                'longitude'               => $coord['lon'],
+                'faa_study_number'        => trim($cols[2] ?? ''),
+                'created_at'              => $now,
+                'updated_at'              => $now,
+            ];
+            $count++;
+            $progress->advance();
+
+            if (count($batch) >= 500) {
+                $this->flushAsrs($batch);
+                $batch = [];
+            }
+        }
+        if (! empty($batch)) $this->flushAsrs($batch);
+
+        fclose($fh);
+        $progress->finish();
+        $this->newLine();
+
+        return $count;
+    }
+
+    private function flushAsrs(array $batch): void
+    {
+        DB::table('fcc_asr_registrations')->upsert(
+            array_values($batch),
+            ['asr_number'],
+            ['owner', 'structure_type', 'overall_height_meters',
+             'latitude', 'longitude', 'faa_study_number', 'updated_at']
+        );
+    }
+
+    private function mapStructureType(string $code): ?string
+    {
+        $code = strtoupper(trim($code));
+        return match ($code) {
+            'GTOWER', 'GUYED', 'GTW'  => 'guyed',
+            'STOWER', 'SELF', 'STW'   => 'self_supporting',
+            'POLE', 'MAST'            => 'monopole',
+            'BANT', 'BLDG', 'BUILDING', 'BMAST' => 'building',
+            default                   => null,
+        };
+    }
+
+    private function dms(string $dir, $deg, $min, $sec): ?float
+    {
+        $deg = (float) $deg; $min = (float) $min; $sec = (float) $sec;
+        if ($deg == 0 && $min == 0 && $sec == 0) return null;
+        $dec = $deg + ($min / 60) + ($sec / 3600);
+        return in_array(strtoupper($dir), ['S', 'W'], true) ? -$dec : $dec;
+    }
+
+    private function download(string $url, string $dest): bool
+    {
+        $ch = curl_init($url);
+        $fp = fopen($dest, 'wb');
+        curl_setopt_array($ch, [
+            CURLOPT_FILE => $fp,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_USERAGENT => 'curl/8.5.0',
+            CURLOPT_HTTPHEADER => ['Accept: */*'],
+            CURLOPT_TIMEOUT => 600,
+            CURLOPT_FAILONERROR => true,
+        ]);
+        $ok = curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+        return (bool) $ok && filesize($dest) > 0;
+    }
+}

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -80,33 +80,40 @@ class FccImportBulkCommand extends Command
     ];
 
     /**
-     * Column order in am_eng_data.dat / fm_eng_data.dat / tv_eng_data.dat.
-     * Different per file but share several common fields. We extract:
-     *   facility_id, station_class, lat/lon (computed), ERP, HAAT
+     * Column positions verified empirically against current CDBS dumps.
+     * Each {svc}_eng_data.dat has slightly different column ordering
+     * (FM: 73 cols, TV: 75 cols, AM: 17 cols — AM has no lat/lon).
      */
     private const FM_ENG_COLS = [
-        'application_id' => 0,
-        'callsign'       => 1,
-        'station_class'  => 2,
-        'effective_erp'  => 3,
-        'haat_horiz_va'  => 4,
-        'haat_vert_va'   => 5,
-        'amsl'           => 6,
-        'agl'            => 7,
-        'directional_ant_id' => 8,
-        'lat_dir'        => 9,
-        'lat_deg'        => 10,
-        'lat_min'        => 11,
-        'lat_sec'        => 12,
-        'lon_dir'        => 13,
-        'lon_deg'        => 14,
-        'lon_min'        => 15,
-        'lon_sec'        => 16,
-        'rcamsl_horiz_mtr' => 17,
-        'rcamsl_vert_mtr'  => 18,
-        'facility_id'    => 19,
-        'station_channel'=> 20,
-        'frequency'      => 21,
+        'service'      => 7,
+        'facility_id'  => 20,
+        'erp_kw'       => 29,
+        'lat_deg'      => 30,
+        'lat_dir'      => 31,
+        'lat_min'      => 32,
+        'lat_sec'      => 33,
+        'lon_deg'      => 34,
+        'lon_dir'      => 35,
+        'lon_min'      => 36,
+        'lon_sec'      => 37,
+        'haat_meters'  => 40,
+        'amsl_meters'  => 48,
+        'station_class'=> 50,
+    ];
+
+    private const TV_ENG_COLS = [
+        'facility_id'  => 21,
+        'lat_deg'      => 29,
+        'lat_dir'      => 30,
+        'lat_min'      => 31,
+        'lat_sec'      => 32,
+        'lon_deg'      => 33,
+        'lon_dir'      => 34,
+        'lon_min'      => 35,
+        'lon_sec'      => 36,
+        'haat_meters'  => 41,
+        'erp_kw'       => 42,
+        'amsl_meters'  => 47,
     ];
 
     public function handle(): int
@@ -160,13 +167,17 @@ class FccImportBulkCommand extends Command
         $this->line('  '.number_format(count($facilityIdMap)).' facilities imported');
         $this->newLine();
 
-        // 4. Augment with engineering data (lat/lon, ERP, HAAT) per service
+        // 4. Augment with engineering data (lat/lon, ERP, HAAT) per service.
+        //    AM has no coordinates in am_eng_data — skip it (AM lat/lon
+        //    lives in am_ant_sys.dat which requires a separate join path).
         foreach ($services as $svc) {
+            if ($svc === 'am') continue;
             $eng = "{$cacheDir}/{$svc}_eng_data.dat";
             if (! file_exists($eng)) continue;
 
+            $cols = $svc === 'tv' ? self::TV_ENG_COLS : self::FM_ENG_COLS;
             $this->info("Applying {$svc}_eng_data → coordinates / ERP / HAAT…");
-            $count = $this->applyEngineeringData($eng, $facilityIdMap);
+            $count = $this->applyEngineeringData($eng, $facilityIdMap, $cols);
             $this->line("  {$count} facilities updated with engineering data");
         }
         $this->newLine();
@@ -437,15 +448,16 @@ class FccImportBulkCommand extends Command
     }
 
     /**
-     * Stream {fm,am,tv}_eng_data.dat and update fcc_facilities with
-     * lat/lon/HAAT/AMSL pulled from the engineering record.
+     * Stream {fm,tv}_eng_data.dat and update fcc_facilities with
+     * lat/lon/HAAT/AMSL pulled from the engineering record. Column
+     * positions vary per service — pass the appropriate map.
      */
-    private function applyEngineeringData(string $path, array $facMap): int
+    private function applyEngineeringData(string $path, array $facMap, array $cols): int
     {
         $fh = fopen($path, 'r');
         if (! $fh) return 0;
 
-        $cols = self::FM_ENG_COLS;
+        $minCols = max($cols) + 1;
         $count = 0;
         $batch = [];
 
@@ -453,7 +465,7 @@ class FccImportBulkCommand extends Command
             $line = fgets($fh);
             if ($line === false) break;
             $row = explode('|', rtrim($line, "\r\n"));
-            if (count($row) < 22) continue;
+            if (count($row) < $minCols) continue;
 
             $facilityId = trim($row[$cols['facility_id']] ?? '');
             if (! isset($facMap[$facilityId])) continue;
@@ -470,8 +482,8 @@ class FccImportBulkCommand extends Command
                 $row[$cols['lon_min']] ?? 0,
                 $row[$cols['lon_sec']] ?? 0
             );
-            $haat = (float) ($row[$cols['haat_horiz_va']] ?? 0);
-            $amsl = (float) ($row[$cols['rcamsl_horiz_mtr']] ?? $row[$cols['amsl']] ?? 0);
+            $haat = (float) ($row[$cols['haat_meters']] ?? 0);
+            $amsl = (float) ($row[$cols['amsl_meters']] ?? 0);
 
             if ($lat === null && $lon === null && $haat == 0 && $amsl == 0) continue;
 

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -273,18 +273,25 @@ class FccImportBulkCommand extends Command
 
     private function flushLicensees(array $batch): int
     {
-        $touched = 0;
-        foreach ($batch as $facilityId => $licensee) {
-            $touched += DB::table('fcc_licenses')
-                ->whereIn('facility_id', function ($q) use ($facilityId) {
-                    $q->select('id')->from('fcc_facilities')->where('facility_id', $facilityId);
-                })
-                ->update(['licensee' => $licensee]);
-            DB::table('fcc_facilities')
-                ->where('facility_id', $facilityId)
-                ->update(['owner' => $licensee]);
-        }
-        return $touched;
+        if (empty($batch)) return 0;
+
+        return DB::transaction(function () use ($batch) {
+            $touched = 0;
+            $pdo = DB::connection()->getPdo();
+            $facUpdate = $pdo->prepare(
+                'UPDATE fcc_facilities SET owner = ? WHERE facility_id = ?'
+            );
+            $licUpdate = $pdo->prepare(
+                'UPDATE fcc_licenses SET licensee = ? WHERE facility_id IN '
+                .'(SELECT id FROM fcc_facilities WHERE facility_id = ?)'
+            );
+            foreach ($batch as $facilityId => $licensee) {
+                $facUpdate->execute([$licensee, $facilityId]);
+                $licUpdate->execute([$licensee, $facilityId]);
+                $touched += $licUpdate->rowCount();
+            }
+            return $touched;
+        });
     }
 
     /**
@@ -506,20 +513,35 @@ class FccImportBulkCommand extends Command
         return $count;
     }
 
+    /**
+     * Flush an engineering batch as a single transaction — without
+     * wrapping the per-row UPDATEs in a transaction SQLite fsyncs
+     * after every statement, making the pass take 30+ minutes for
+     * the FM dataset. With a wrap it finishes in seconds.
+     */
     private function flushEngineering(array $batch): int
     {
-        $touched = 0;
-        foreach ($batch as $row) {
-            $touched += DB::table('fcc_facilities')
-                ->where('facility_id', $row['facility_id'])
-                ->update([
-                    'latitude' => $row['latitude'],
-                    'longitude' => $row['longitude'],
-                    'antenna_haat_meters' => $row['antenna_haat_meters'],
-                    'antenna_amsl_meters' => $row['antenna_amsl_meters'],
+        if (empty($batch)) return 0;
+
+        return DB::transaction(function () use ($batch) {
+            $touched = 0;
+            $stmt = DB::connection()->getPdo()->prepare(
+                'UPDATE fcc_facilities SET latitude = ?, longitude = ?, '
+                .'antenna_haat_meters = ?, antenna_amsl_meters = ? '
+                .'WHERE facility_id = ?'
+            );
+            foreach ($batch as $row) {
+                $stmt->execute([
+                    $row['latitude'],
+                    $row['longitude'],
+                    $row['antenna_haat_meters'],
+                    $row['antenna_amsl_meters'],
+                    $row['facility_id'],
                 ]);
-        }
-        return $touched;
+                $touched += $stmt->rowCount();
+            }
+            return $touched;
+        });
     }
 
     /* ---------- helpers ---------- */

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -1,0 +1,583 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FccFacility;
+use App\Models\FccLicense;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use ZipArchive;
+
+/**
+ * Bulk-import every U.S. broadcast facility from the FCC's CDBS daily
+ * data dumps. The CDBS dataset is the historical broadcast database
+ * mirrored daily at:
+ *   https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/
+ *
+ * Files used:
+ *   - facility.zip      → facility.dat (master facility table)
+ *   - am_eng_data.zip   → am_eng_data.dat (AM engineering: power, lat/lon)
+ *   - fm_eng_data.zip   → fm_eng_data.dat (FM engineering: ERP, HAAT, lat/lon)
+ *   - tv_eng_data.zip   → tv_eng_data.dat (TV engineering: channel, lat/lon)
+ *
+ * All files are pipe-delimited, no header. Column order follows the
+ * FCC's published CDBS schema (cdbsdoc.txt).
+ *
+ * Usage:
+ *   php artisan fcc:import-bulk             # full sync (downloads ~22MB, imports ~30K stations)
+ *   php artisan fcc:import-bulk --limit=500 # smoke test
+ *   php artisan fcc:import-bulk --skip-download   # use cached files in storage/app/cdbs/
+ *   php artisan fcc:import-bulk --service=fm      # only AM/FM/TV
+ */
+class FccImportBulkCommand extends Command
+{
+    protected $signature = 'fcc:import-bulk
+                            {--limit= : Cap the number of facilities imported per service (smoke test)}
+                            {--skip-download : Reuse cached zip files in storage/app/cdbs/}
+                            {--skip-licensees : Don\'t pull party/fac_party (saves ~16MB / faster)}
+                            {--service= : Limit to am, fm, or tv}';
+
+    protected $description = 'Bulk-import every U.S. broadcast facility from FCC CDBS daily dumps';
+
+    private const CDBS_BASE = 'https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/';
+
+    /**
+     * Column order in facility.dat (per FCC cdbsdoc.txt). 0-indexed.
+     * Verified against CDBS documentation.
+     */
+    private const FACILITY_COLS = [
+        'comm_city'            => 0,
+        'comm_state'           => 1,
+        'eeo_rpt_ind'          => 2,
+        'fac_address1'         => 3,
+        'fac_address2'         => 4,
+        'fac_callsign'         => 5,
+        'fac_channel'          => 6,
+        'fac_city'             => 7,
+        'fac_country'          => 8,
+        'fac_frequency'        => 9,
+        'fac_service'          => 10,
+        'fac_state'            => 11,
+        'fac_status_date'      => 12,
+        'fac_type'             => 13,
+        'facility_id'          => 14,
+        'lic_expiration_date'  => 15,
+        'fac_status'           => 16,
+        'fac_zip1'             => 17,
+        'fac_zip2'             => 18,
+        'station_type'         => 19,
+        'assoc_facility_id'    => 20,
+        'callsign_eff_date'    => 21,
+        'tsid_ntsc'            => 22,
+        'tsid_dtv'             => 23,
+        'digital_status'       => 24,
+        'sat_tv'               => 25,
+        'network_affil'        => 26,
+        'nielsen_dma'          => 27,
+        'tv_virtual_channel'   => 28,
+        'last_change_date'     => 29,
+    ];
+
+    /**
+     * Column order in am_eng_data.dat / fm_eng_data.dat / tv_eng_data.dat.
+     * Different per file but share several common fields. We extract:
+     *   facility_id, station_class, lat/lon (computed), ERP, HAAT
+     */
+    private const FM_ENG_COLS = [
+        'application_id' => 0,
+        'callsign'       => 1,
+        'station_class'  => 2,
+        'effective_erp'  => 3,
+        'haat_horiz_va'  => 4,
+        'haat_vert_va'   => 5,
+        'amsl'           => 6,
+        'agl'            => 7,
+        'directional_ant_id' => 8,
+        'lat_dir'        => 9,
+        'lat_deg'        => 10,
+        'lat_min'        => 11,
+        'lat_sec'        => 12,
+        'lon_dir'        => 13,
+        'lon_deg'        => 14,
+        'lon_min'        => 15,
+        'lon_sec'        => 16,
+        'rcamsl_horiz_mtr' => 17,
+        'rcamsl_vert_mtr'  => 18,
+        'facility_id'    => 19,
+        'station_channel'=> 20,
+        'frequency'      => 21,
+    ];
+
+    public function handle(): int
+    {
+        $cacheDir = storage_path('app/cdbs');
+        if (! is_dir($cacheDir)) mkdir($cacheDir, 0755, true);
+
+        $services = $this->option('service')
+            ? [strtolower($this->option('service'))]
+            : ['am', 'fm', 'tv'];
+
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+
+        $this->info('FCC CDBS bulk import — every U.S. broadcast facility');
+        $this->info("Cache dir: {$cacheDir}");
+        $this->newLine();
+
+        // 1. Download (or use cached) zip files
+        $files = ['facility.zip'];
+        foreach ($services as $svc) $files[] = "{$svc}_eng_data.zip";
+
+        foreach ($files as $f) {
+            $local = "{$cacheDir}/{$f}";
+            if (! $this->option('skip-download') || ! file_exists($local)) {
+                $this->info("Downloading {$f}…");
+                if (! $this->download(self::CDBS_BASE.$f, $local)) {
+                    $this->error("  failed: ".self::CDBS_BASE.$f);
+                    return self::FAILURE;
+                }
+                $this->line('  '.number_format(filesize($local) / 1024 / 1024, 1).' MB');
+            } else {
+                $this->line("Cached: {$f}");
+            }
+        }
+        $this->newLine();
+
+        // 2. Unzip
+        foreach ($files as $f) {
+            $zip = new ZipArchive;
+            if ($zip->open("{$cacheDir}/{$f}") !== true) {
+                $this->error("Failed to open {$f}");
+                return self::FAILURE;
+            }
+            $zip->extractTo($cacheDir);
+            $zip->close();
+        }
+
+        // 3. Import facilities (master table)
+        $this->info('Importing facilities (broadcast master table)…');
+        $facilityIdMap = $this->importFacilities("{$cacheDir}/facility.dat", $services, $limit);
+        $this->line('  '.number_format(count($facilityIdMap)).' facilities imported');
+        $this->newLine();
+
+        // 4. Augment with engineering data (lat/lon, ERP, HAAT) per service
+        foreach ($services as $svc) {
+            $eng = "{$cacheDir}/{$svc}_eng_data.dat";
+            if (! file_exists($eng)) continue;
+
+            $this->info("Applying {$svc}_eng_data → coordinates / ERP / HAAT…");
+            $count = $this->applyEngineeringData($eng, $facilityIdMap);
+            $this->line("  {$count} facilities updated with engineering data");
+        }
+        $this->newLine();
+
+        // 5. Optional: pull licensee names from party.zip + fac_party.zip
+        if (! $this->option('skip-licensees')) {
+            $this->info('Pulling licensee names (party.zip + fac_party.zip)…');
+            $partyOk = $this->option('skip-download') && file_exists("{$cacheDir}/party.zip")
+                ? true
+                : $this->download(self::CDBS_BASE.'party.zip', "{$cacheDir}/party.zip");
+            $facPartyOk = $this->option('skip-download') && file_exists("{$cacheDir}/fac_party.zip")
+                ? true
+                : $this->download(self::CDBS_BASE.'fac_party.zip', "{$cacheDir}/fac_party.zip");
+
+            if ($partyOk && $facPartyOk) {
+                $this->unzipIfNeeded("{$cacheDir}/party.zip", $cacheDir);
+                $this->unzipIfNeeded("{$cacheDir}/fac_party.zip", $cacheDir);
+                $count = $this->applyLicensees("{$cacheDir}/party.dat", "{$cacheDir}/fac_party.dat");
+                $this->line("  {$count} licenses updated with real licensee names");
+            } else {
+                $this->warn('  party data unavailable; skipping licensee names');
+            }
+        }
+        $this->newLine();
+
+        $this->info('Done. Run `php artisan fcc:sync` for the full pipeline.');
+        return self::SUCCESS;
+    }
+
+    private function unzipIfNeeded(string $zipPath, string $destDir): void
+    {
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath) === true) {
+            $zip->extractTo($destDir);
+            $zip->close();
+        }
+    }
+
+    /**
+     * Apply licensee names from party.dat (party_id → name) joined to
+     * fac_party.dat (party_id ↔ facility_id, role_code='LIC' = licensee).
+     */
+    private function applyLicensees(string $partyPath, string $facPartyPath): int
+    {
+        if (! file_exists($partyPath) || ! file_exists($facPartyPath)) return 0;
+
+        // Load party_id → name into memory (~50K rows, name string only)
+        $parties = [];
+        $fh = fopen($partyPath, 'r');
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 8) continue;
+            // party.dat columns: party_id, name, attention_line, addr1, addr2, ...
+            $partyId = trim($cols[0]);
+            $name = trim($cols[1]);
+            if ($partyId !== '' && $name !== '') {
+                $parties[$partyId] = $name;
+            }
+        }
+        fclose($fh);
+
+        // Stream fac_party.dat: facility_id, party_id, role_code (=LIC for licensee)
+        $fh = fopen($facPartyPath, 'r');
+        $batch = [];
+        $touched = 0;
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 5) continue;
+
+            $facilityId = trim($cols[0] ?? '');
+            $partyId    = trim($cols[1] ?? '');
+            $roleCode   = strtoupper(trim($cols[2] ?? ''));
+
+            if ($roleCode !== 'LIC' && $roleCode !== 'LICENSEE' && $roleCode !== 'OWNER') continue;
+            if (! isset($parties[$partyId])) continue;
+
+            $batch[$facilityId] = $parties[$partyId];
+
+            if (count($batch) >= 1000) {
+                $touched += $this->flushLicensees($batch);
+                $batch = [];
+            }
+        }
+        if (! empty($batch)) $touched += $this->flushLicensees($batch);
+        fclose($fh);
+
+        return $touched;
+    }
+
+    private function flushLicensees(array $batch): int
+    {
+        $touched = 0;
+        foreach ($batch as $facilityId => $licensee) {
+            $touched += DB::table('fcc_licenses')
+                ->whereIn('facility_id', function ($q) use ($facilityId) {
+                    $q->select('id')->from('fcc_facilities')->where('facility_id', $facilityId);
+                })
+                ->update(['licensee' => $licensee]);
+            DB::table('fcc_facilities')
+                ->where('facility_id', $facilityId)
+                ->update(['owner' => $licensee]);
+        }
+        return $touched;
+    }
+
+    /**
+     * Stream-download a URL to disk with a curl-style UA (FCC blocks Mozilla).
+     */
+    private function download(string $url, string $dest): bool
+    {
+        $ch = curl_init($url);
+        $fp = fopen($dest, 'wb');
+        curl_setopt_array($ch, [
+            CURLOPT_FILE => $fp,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_USERAGENT => 'curl/8.5.0',
+            CURLOPT_HTTPHEADER => ['Accept: */*'],
+            CURLOPT_TIMEOUT => 600,
+            CURLOPT_FAILONERROR => true,
+        ]);
+        $ok = curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+        return (bool) $ok && filesize($dest) > 0;
+    }
+
+    /**
+     * Stream facility.dat, upserting into fcc_facilities + fcc_licenses.
+     * Returns [facility_id => internal_facility_pk] for the engineering pass.
+     */
+    private function importFacilities(string $path, array $services, ?int $limit): array
+    {
+        $serviceFilter = $this->buildServiceFilter($services);
+        $facilityCol = self::FACILITY_COLS;
+
+        $facMap = [];
+        $countByService = [];
+        $facBatch = [];
+        $licBatch = [];
+        $now = now();
+
+        $fh = fopen($path, 'r');
+        if (! $fh) return [];
+
+        $progress = $this->output->createProgressBar();
+        $progress->setFormat(' %current% facilities [%bar%] %elapsed:6s%');
+        $progress->start();
+
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $cols = explode('|', rtrim($line, "\r\n"));
+            if (count($cols) < 30) continue;
+
+            $service = trim($cols[$facilityCol['fac_service']]);
+            if (! in_array(strtoupper($service), $serviceFilter, true)) continue;
+
+            $facilityId = trim($cols[$facilityCol['facility_id']]);
+            if ($facilityId === '' || ! ctype_digit($facilityId)) continue;
+
+            $callsign = trim($cols[$facilityCol['fac_callsign']]);
+            if ($callsign === '') continue;
+
+            $svcUpper = strtoupper($service);
+            $countByService[$svcUpper] = ($countByService[$svcUpper] ?? 0) + 1;
+            if ($limit !== null && $countByService[$svcUpper] > $limit) continue;
+
+            $city  = trim($cols[$facilityCol['comm_city']]);
+            $state = trim($cols[$facilityCol['comm_state']]);
+            $country = trim($cols[$facilityCol['fac_country']]);
+            $channel = trim($cols[$facilityCol['fac_channel']]);
+            $frequency = trim($cols[$facilityCol['fac_frequency']]);
+            $licExp  = $this->parseDate($cols[$facilityCol['lic_expiration_date']] ?? null);
+            $callsignEff = $this->parseDate($cols[$facilityCol['callsign_eff_date']] ?? null);
+            $facStatus = trim($cols[$facilityCol['fac_status']]);
+            $networkAffil = trim($cols[$facilityCol['network_affil']]);
+            $dma = trim($cols[$facilityCol['nielsen_dma']]);
+
+            // Skip non-US for the demo
+            if ($country !== '' && strtoupper($country) !== 'US') continue;
+
+            $facBatch[$facilityId] = [
+                'facility_id' => $facilityId,
+                'name' => $callsign.($city ? " — {$city}" : ''),
+                'community_of_license' => $city ?: null,
+                'state' => $state ?: null,
+                'owner' => null,  // populated later from party.zip if needed
+                'notes' => $networkAffil ? "Network: {$networkAffil}".($dma ? " | DMA: {$dma}" : '') : null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+
+            $licBatch[] = [
+                'call_sign' => $callsign,
+                'frn' => '',
+                'licensee' => 'Pending — see CDBS party tables',
+                'service' => $this->mapService($svcUpper),
+                'channel_or_frequency' => $this->formatFreq($svcUpper, $frequency, $channel),
+                'expiration_date' => $licExp,
+                'last_renewal_date' => $licExp ? $licExp->copy()->subYears(8) : null,
+                'grant_date' => $callsignEff,
+                'status' => $this->mapStatus($facStatus),
+                'compliance_score' => 100.00,
+                'cdbs_facility_id' => $facilityId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+
+            $progress->advance();
+
+            if (count($facBatch) >= 500) {
+                $this->flushBatch($facBatch, $licBatch, $facMap);
+                $facBatch = [];
+                $licBatch = [];
+            }
+        }
+
+        if (! empty($facBatch)) {
+            $this->flushBatch($facBatch, $licBatch, $facMap);
+        }
+
+        fclose($fh);
+        $progress->finish();
+        $this->newLine();
+
+        return $facMap;
+    }
+
+    /**
+     * Bulk-upsert a batch of facilities + licenses, mapping
+     * cdbs facility_id → internal pk for downstream engineering pass.
+     */
+    private function flushBatch(array $facs, array $licenses, array &$facMap): void
+    {
+        if (empty($facs)) return;
+
+        DB::table('fcc_facilities')->upsert(
+            array_values($facs),
+            ['facility_id'],
+            ['name', 'community_of_license', 'state', 'notes', 'updated_at']
+        );
+
+        $internalIds = DB::table('fcc_facilities')
+            ->whereIn('facility_id', array_keys($facs))
+            ->pluck('id', 'facility_id');
+
+        $licRows = [];
+        foreach ($licenses as $lic) {
+            $cdbsId = $lic['cdbs_facility_id'];
+            unset($lic['cdbs_facility_id']);
+            $lic['facility_id'] = $internalIds[$cdbsId] ?? null;
+            $facMap[$cdbsId] = $lic['facility_id'];
+            $licRows[] = $lic;
+        }
+
+        if (! empty($licRows)) {
+            DB::table('fcc_licenses')->upsert(
+                $licRows,
+                ['call_sign'],
+                ['licensee', 'service', 'channel_or_frequency', 'expiration_date',
+                 'last_renewal_date', 'grant_date', 'status', 'facility_id', 'updated_at']
+            );
+        }
+    }
+
+    /**
+     * Stream {fm,am,tv}_eng_data.dat and update fcc_facilities with
+     * lat/lon/HAAT/AMSL pulled from the engineering record.
+     */
+    private function applyEngineeringData(string $path, array $facMap): int
+    {
+        $fh = fopen($path, 'r');
+        if (! $fh) return 0;
+
+        $cols = self::FM_ENG_COLS;
+        $count = 0;
+        $batch = [];
+
+        while (! feof($fh)) {
+            $line = fgets($fh);
+            if ($line === false) break;
+            $row = explode('|', rtrim($line, "\r\n"));
+            if (count($row) < 22) continue;
+
+            $facilityId = trim($row[$cols['facility_id']] ?? '');
+            if (! isset($facMap[$facilityId])) continue;
+
+            $lat = $this->dms2decimal(
+                $row[$cols['lat_dir']] ?? '',
+                $row[$cols['lat_deg']] ?? 0,
+                $row[$cols['lat_min']] ?? 0,
+                $row[$cols['lat_sec']] ?? 0
+            );
+            $lon = $this->dms2decimal(
+                $row[$cols['lon_dir']] ?? '',
+                $row[$cols['lon_deg']] ?? 0,
+                $row[$cols['lon_min']] ?? 0,
+                $row[$cols['lon_sec']] ?? 0
+            );
+            $haat = (float) ($row[$cols['haat_horiz_va']] ?? 0);
+            $amsl = (float) ($row[$cols['rcamsl_horiz_mtr']] ?? $row[$cols['amsl']] ?? 0);
+
+            if ($lat === null && $lon === null && $haat == 0 && $amsl == 0) continue;
+
+            $batch[] = [
+                'facility_id' => $facilityId,
+                'latitude' => $lat,
+                'longitude' => $lon,
+                'antenna_haat_meters' => $haat ?: null,
+                'antenna_amsl_meters' => $amsl ?: null,
+            ];
+
+            if (count($batch) >= 500) {
+                $count += $this->flushEngineering($batch);
+                $batch = [];
+            }
+        }
+        if (! empty($batch)) $count += $this->flushEngineering($batch);
+
+        fclose($fh);
+        return $count;
+    }
+
+    private function flushEngineering(array $batch): int
+    {
+        $touched = 0;
+        foreach ($batch as $row) {
+            $touched += DB::table('fcc_facilities')
+                ->where('facility_id', $row['facility_id'])
+                ->update([
+                    'latitude' => $row['latitude'],
+                    'longitude' => $row['longitude'],
+                    'antenna_haat_meters' => $row['antenna_haat_meters'],
+                    'antenna_amsl_meters' => $row['antenna_amsl_meters'],
+                ]);
+        }
+        return $touched;
+    }
+
+    /* ---------- helpers ---------- */
+
+    private function buildServiceFilter(array $services): array
+    {
+        $map = [
+            'am' => ['AM', 'AB'],
+            'fm' => ['FM', 'FB', 'FX', 'FL'],
+            'tv' => ['TV', 'DT', 'DC', 'CA', 'LD', 'LP', 'TX'],
+        ];
+        $out = [];
+        foreach ($services as $s) {
+            $out = array_merge($out, $map[$s] ?? []);
+        }
+        return $out ?: ['AM', 'FM', 'TV', 'FB', 'FX', 'FL', 'DT', 'DC', 'CA', 'LD', 'LP', 'TX', 'AB'];
+    }
+
+    private function mapService(string $code): string
+    {
+        return match (true) {
+            in_array($code, ['AM', 'AB']) => 'AM',
+            in_array($code, ['FM', 'FB', 'FX']) => 'FM',
+            $code === 'FL' => 'LPFM',
+            in_array($code, ['TV', 'DT', 'DC', 'CA']) => 'TV',
+            in_array($code, ['LP', 'LD', 'TX']) => 'LPTV',
+            default => 'OTHER',
+        };
+    }
+
+    private function mapStatus(string $cdbs): string
+    {
+        $cdbs = strtoupper(trim($cdbs));
+        return match ($cdbs) {
+            'LICEN', 'LIC', 'LICENSED' => 'active',
+            'EXPIR', 'EXPIRED'         => 'non_compliant',
+            'CANCEL', 'CANCELLED'      => 'cancelled',
+            'SILENT', 'SILEN'          => 'silent',
+            default                    => 'active',
+        };
+    }
+
+    private function formatFreq(string $service, string $freq, string $channel): ?string
+    {
+        $freq = trim($freq);
+        $channel = trim($channel);
+        return match (true) {
+            in_array($service, ['AM', 'AB']) && $freq !== '' => "{$freq} kHz",
+            in_array($service, ['FM', 'FB', 'FX', 'FL']) && $freq !== '' => "{$freq} MHz",
+            in_array($service, ['TV', 'DT', 'DC', 'CA', 'LD', 'LP', 'TX']) && $channel !== '' => "Ch. {$channel}",
+            default => $freq !== '' ? $freq : ($channel !== '' ? "Ch. {$channel}" : null),
+        };
+    }
+
+    private function parseDate(?string $raw): ?Carbon
+    {
+        if (! $raw || trim($raw) === '') return null;
+        try {
+            // CDBS dates are typically ISO yyyy-mm-dd
+            return Carbon::parse(trim($raw));
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function dms2decimal(string $dir, $deg, $min, $sec): ?float
+    {
+        $deg = (float) $deg; $min = (float) $min; $sec = (float) $sec;
+        if ($deg == 0 && $min == 0 && $sec == 0) return null;
+        $dec = $deg + ($min / 60) + ($sec / 3600);
+        return in_array(strtoupper(trim($dir)), ['S', 'W'], true) ? -$dec : $dec;
+    }
+}

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -253,12 +253,19 @@ class FccImportBulkCommand extends Command
         }
         fclose($fh);
 
+        // Pre-load cdbs_facility_id → internal_pk so flushLicensees can
+        // do a single UPDATE WHERE id IN (...) per batch without a
+        // subquery per row.
+        $facilityPkMap = DB::table('fcc_facilities')
+            ->pluck('id', 'facility_id')
+            ->toArray();
+
         // Stream fac_party.dat. Schema (verified live):
         //   0: facility_id
         //   1: party_id
         //   2: role_code   ('LICEN' = licensee, 'CONTAC' = contact, ...)
         $fh = fopen($facPartyPath, 'r');
-        $batch = [];
+        $batch = [];        // facility_id (cdbs) → name
         $touched = 0;
         while (! feof($fh)) {
             $line = fgets($fh);
@@ -270,7 +277,6 @@ class FccImportBulkCommand extends Command
             $partyId    = trim($cols[1] ?? '');
             $roleCode   = strtoupper(trim($cols[2] ?? ''));
 
-            // CDBS uses 'LICEN' for licensee. Accept all forms we've seen.
             if (! in_array($roleCode, ['LICEN', 'LIC', 'LICENSEE', 'OWNER'], true)) continue;
             if (! isset($parties[$partyId])) continue;
             if (! ctype_digit($facilityId)) continue;
@@ -278,35 +284,56 @@ class FccImportBulkCommand extends Command
             $batch[$facilityId] = $parties[$partyId];
 
             if (count($batch) >= 1000) {
-                $touched += $this->flushLicensees($batch);
+                $touched += $this->flushLicensees($batch, $facilityPkMap);
                 $batch = [];
             }
         }
-        if (! empty($batch)) $touched += $this->flushLicensees($batch);
+        if (! empty($batch)) $touched += $this->flushLicensees($batch, $facilityPkMap);
         fclose($fh);
 
         return $touched;
     }
 
-    private function flushLicensees(array $batch): int
+    /**
+     * Bulk-update licensee names for a batch of cdbs_facility_id → name
+     * pairs. Uses the pre-loaded $pkMap so we never run a subquery.
+     */
+    private function flushLicensees(array $batch, array $pkMap): int
     {
         if (empty($batch)) return 0;
 
-        return DB::transaction(function () use ($batch) {
+        return DB::transaction(function () use ($batch, $pkMap) {
             $touched = 0;
             $pdo = DB::connection()->getPdo();
-            $facUpdate = $pdo->prepare(
-                'UPDATE fcc_facilities SET owner = ? WHERE facility_id = ?'
-            );
-            $licUpdate = $pdo->prepare(
-                'UPDATE fcc_licenses SET licensee = ? WHERE facility_id IN '
-                .'(SELECT id FROM fcc_facilities WHERE facility_id = ?)'
-            );
-            foreach ($batch as $facilityId => $licensee) {
-                $facUpdate->execute([$licensee, $facilityId]);
-                $licUpdate->execute([$licensee, $facilityId]);
-                $touched += $licUpdate->rowCount();
+
+            // Group facilities by name so we can UPDATE WHERE id IN (…)
+            // for each distinct licensee — orders of magnitude fewer
+            // queries than per-row UPDATEs.
+            $byName = [];        // licensee_name → [internal_pk, ...]
+            $facByName = [];     // licensee_name → [cdbs_facility_id, ...]
+            foreach ($batch as $cdbsId => $name) {
+                $facByName[$name][] = $cdbsId;
+                if (isset($pkMap[$cdbsId])) {
+                    $byName[$name][] = $pkMap[$cdbsId];
+                }
             }
+
+            // Update fcc_facilities.owner by cdbs facility_id
+            foreach ($facByName as $name => $cdbsIds) {
+                $place = implode(',', array_fill(0, count($cdbsIds), '?'));
+                $stmt = $pdo->prepare("UPDATE fcc_facilities SET owner = ? WHERE facility_id IN ({$place})");
+                $stmt->execute(array_merge([$name], $cdbsIds));
+            }
+
+            // Update fcc_licenses.licensee by internal facility pk
+            foreach ($byName as $name => $internalIds) {
+                if (empty($internalIds)) continue;
+                $place = implode(',', array_fill(0, count($internalIds), '?'));
+                $stmt = $pdo->prepare("UPDATE fcc_licenses SET licensee = ? WHERE facility_id IN ({$place})");
+                $stmt->execute(array_merge([$name], $internalIds));
+                $touched += $stmt->rowCount();
+            }
+
             return $touched;
         });
     }

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -224,24 +224,39 @@ class FccImportBulkCommand extends Command
     {
         if (! file_exists($partyPath) || ! file_exists($facPartyPath)) return 0;
 
-        // Load party_id → name into memory (~50K rows, name string only)
+        // Load party_id → name into memory (~50K rows).
+        // party.dat schema (verified live):
+        //   0: party_id
+        //   1: address1
+        //   4: city
+        //   6: country
+        //   10: party_name (canonical entity name) ← what we want
+        //   12: state
+        //   13: zip
         $parties = [];
         $fh = fopen($partyPath, 'r');
         while (! feof($fh)) {
             $line = fgets($fh);
             if ($line === false) break;
             $cols = explode('|', rtrim($line, "\r\n"));
-            if (count($cols) < 8) continue;
-            // party.dat columns: party_id, name, attention_line, addr1, addr2, ...
+            if (count($cols) < 11) continue;
             $partyId = trim($cols[0]);
-            $name = trim($cols[1]);
-            if ($partyId !== '' && $name !== '') {
+            // Try col 10 first (typical real-party row), then col 9 as
+            // a fallback for the placeholder rows where address fields
+            // collapsed and name shifted left.
+            $name = trim($cols[10] ?? '');
+            if ($name === '') $name = trim($cols[9] ?? '');
+            if ($partyId !== '' && ctype_digit($partyId) && $name !== ''
+                && stripos($name, 'PARTY INFO NOT FOUND') === false) {
                 $parties[$partyId] = $name;
             }
         }
         fclose($fh);
 
-        // Stream fac_party.dat: facility_id, party_id, role_code (=LIC for licensee)
+        // Stream fac_party.dat. Schema (verified live):
+        //   0: facility_id
+        //   1: party_id
+        //   2: role_code   ('LICEN' = licensee, 'CONTAC' = contact, ...)
         $fh = fopen($facPartyPath, 'r');
         $batch = [];
         $touched = 0;
@@ -249,14 +264,16 @@ class FccImportBulkCommand extends Command
             $line = fgets($fh);
             if ($line === false) break;
             $cols = explode('|', rtrim($line, "\r\n"));
-            if (count($cols) < 5) continue;
+            if (count($cols) < 3) continue;
 
             $facilityId = trim($cols[0] ?? '');
             $partyId    = trim($cols[1] ?? '');
             $roleCode   = strtoupper(trim($cols[2] ?? ''));
 
-            if ($roleCode !== 'LIC' && $roleCode !== 'LICENSEE' && $roleCode !== 'OWNER') continue;
+            // CDBS uses 'LICEN' for licensee. Accept all forms we've seen.
+            if (! in_array($roleCode, ['LICEN', 'LIC', 'LICENSEE', 'OWNER'], true)) continue;
             if (! isset($parties[$partyId])) continue;
+            if (! ctype_digit($facilityId)) continue;
 
             $batch[$facilityId] = $parties[$partyId];
 

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -632,6 +632,12 @@ class FccImportBulkCommand extends Command
     {
         $freq = trim($freq);
         $channel = trim($channel);
+
+        // Strip trailing zeros so 88.300000 → 88.3, 1470.000000 → 1470.
+        if ($freq !== '' && is_numeric($freq)) {
+            $freq = rtrim(rtrim($freq, '0'), '.');
+        }
+
         return match (true) {
             in_array($service, ['AM', 'AB']) && $freq !== '' => "{$freq} kHz",
             in_array($service, ['FM', 'FB', 'FX', 'FL']) && $freq !== '' => "{$freq} MHz",

--- a/app/Console/Commands/FccImportBulkCommand.php
+++ b/app/Console/Commands/FccImportBulkCommand.php
@@ -396,6 +396,13 @@ class FccImportBulkCommand extends Command
             $callsign = trim($cols[$facilityCol['fac_callsign']]);
             if ($callsign === '') continue;
 
+            // Skip CDBS records where fac_callsign is actually an FCC
+            // application/file number (e.g. "780118AD", "10269") — those
+            // are unbuilt construction-permit applications, not licensed
+            // stations. Real broadcast call signs are 3-6 alphanumeric
+            // chars starting with a letter (K, W, or international like K-).
+            if (! preg_match('/^[A-Z][A-Z0-9-]{2,7}$/', $callsign)) continue;
+
             $svcUpper = strtoupper($service);
             $countByService[$svcUpper] = ($countByService[$svcUpper] ?? 0) + 1;
             if ($limit !== null && $countByService[$svcUpper] > $limit) continue;

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -55,7 +55,8 @@ class FccImportCommand extends Command
                 }
 
                 if ($this->option('dry-run')) {
-                    $this->line("  · {$call}: {$data['licensee']} ({$data['service']} {$data['frequency']}) — facility {$data['facility_id']}");
+                    $src = $data['_source_url'] ?? 'unknown';
+                    $this->line("  · {$call}: {$data['licensee']} ({$data['service']} {$data['frequency']}) — facility {$data['facility_id']} [src: {$src}]");
                     continue;
                 }
 
@@ -96,94 +97,163 @@ class FccImportCommand extends Command
     }
 
     /**
-     * Fetch one station's public facility record from the FCC.
+     * Fetch one station's public facility record from opendata.fcc.gov.
      *
-     * The FCC's public-search endpoints have shifted around over time.
-     * We try multiple known-good URL shapes in order. If you're hitting
-     * this in production and all fall through, the canonical fallback is
-     * a CDBS bulk-data loader (https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/).
+     * The FCC publishes broadcast engineering data via the Socrata SODA
+     * API at opendata.fcc.gov — these endpoints are stable and don't
+     * require auth for low-volume queries.
+     *
+     * We try the broadcast engineering dataset first, falling back to
+     * the AM/FM Query and LMS endpoints if Socrata returns nothing.
      */
     protected function fetchFccPublicFacility(string $call): ?array
     {
-        $candidates = [
-            // 1. Public Inspection Files manager — search by callsign query string
-            'https://publicfiles.fcc.gov/api/manager/station/search?searchString='.urlencode($call),
+        // Strip any "-FM" / "-TV" suffix for the search; opendata stores the bare call
+        $bareCall = strtoupper(preg_replace('/-(FM|TV|AM|LP|LD)$/i', '', $call));
 
-            // 2. Same site, callsign as path segment
-            'https://publicfiles.fcc.gov/api/manager/station/'.urlencode($call),
-
-            // 3. LMS public-facility elastic search
-            'https://enterpriseefiling.fcc.gov/dataentry/api/elasticsearch/public/api/public/facility/search?callSign='.urlencode($call),
-        ];
-
-        foreach ($candidates as $url) {
-            try {
-                $response = Http::timeout(15)
-                    ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
-                    ->acceptJson()
-                    ->get($url);
-
-                if (! $response->ok()) {
-                    continue;
-                }
-
-                $payload = $response->json();
-                if (! is_array($payload) || empty($payload)) {
-                    continue;
-                }
-
-                $hit = $this->extractFirstStation($payload);
-                if (! $hit) {
-                    continue;
-                }
-
-                $facilityId = (string) data_get($hit, 'facilityId') ?: (string) data_get($hit, 'facility_id') ?: (string) data_get($hit, 'id');
-                if (! $facilityId) {
-                    continue;
-                }
-
-                return [
-                    'facility_id'     => $facilityId,
-                    'facility_name'   => data_get($hit, 'transmitterName') ?? data_get($hit, 'facilityName') ?? null,
-                    'frn'             => (string) (data_get($hit, 'frn') ?? data_get($hit, 'licenseeFrn') ?? ''),
-                    'licensee'        => data_get($hit, 'licensee') ?? data_get($hit, 'entityName') ?? data_get($hit, 'licenseeName') ?? 'Unknown',
-                    'service'         => $this->mapService((string) (data_get($hit, 'serviceCode') ?? data_get($hit, 'service') ?? 'OTHER')),
-                    'frequency'       => (string) (data_get($hit, 'frequency') ?? data_get($hit, 'channel') ?? ''),
-                    'community'       => data_get($hit, 'community.city') ?? data_get($hit, 'communityCity') ?? data_get($hit, 'communityServed.city'),
-                    'state'           => data_get($hit, 'community.state') ?? data_get($hit, 'communityState') ?? data_get($hit, 'communityServed.state'),
-                    'expiration_date' => data_get($hit, 'licenseExpirationDate') ?? data_get($hit, 'expirationDate'),
-                    '_source_url'     => $url,
-                ];
-            } catch (\Throwable $e) {
-                // try next URL
-                continue;
-            }
+        // 1) opendata.fcc.gov — broadcast engineering (AM/FM/TV) — stable Socrata API
+        //    Dataset: "AM, FM, TV Broadcast Engineering Data" (cd28-25ar)
+        $hit = $this->trySocrata('cd28-25ar', $bareCall);
+        if ($hit) {
+            return $this->normalizeSocrata($hit);
         }
+
+        // 2) opendata.fcc.gov — broadcast facility data (alt dataset)
+        $hit = $this->trySocrata('iqaq-mbpb', $bareCall);
+        if ($hit) {
+            return $this->normalizeSocrata($hit);
+        }
+
+        // 3) FCC FM Query CGI (pipe-delimited; has been stable since the 90s)
+        $hit = $this->tryFccQueryCgi('fmq', $bareCall);
+        if ($hit) return $hit;
+
+        $hit = $this->tryFccQueryCgi('amq', $bareCall);
+        if ($hit) return $hit;
+
+        $hit = $this->tryFccQueryCgi('tvq', $bareCall);
+        if ($hit) return $hit;
 
         return null;
     }
 
     /**
-     * Extract the first station-like record from a heterogeneous payload.
+     * Query opendata.fcc.gov Socrata endpoint for a call sign.
      */
-    protected function extractFirstStation(array $payload): ?array
+    protected function trySocrata(string $datasetId, string $call): ?array
     {
-        // Common shapes:
-        //  - { stations: [ {...} ] }
-        //  - { hits: [ {...} ] }
-        //  - { data: [ {...} ] }
-        //  - [ {...} ]            (bare array)
-        //  - { facilityId: ... }  (single record)
-        foreach (['stations', 'hits', 'data', 'results', 'records'] as $key) {
-            if (isset($payload[$key]) && is_array($payload[$key]) && ! empty($payload[$key])) {
-                return $payload[$key][0];
+        $url = "https://opendata.fcc.gov/resource/{$datasetId}.json";
+
+        try {
+            $response = Http::timeout(15)
+                ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
+                ->acceptJson()
+                ->get($url, ['call_sign' => $call, '$limit' => 1]);
+
+            if (! $response->ok()) return null;
+
+            $rows = $response->json();
+            return is_array($rows) && ! empty($rows) ? $rows[0] : null;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Normalize a Socrata broadcast-engineering row to our schema.
+     * Field names vary slightly between FCC datasets; we cover both.
+     */
+    protected function normalizeSocrata(array $h): array
+    {
+        $service = $this->mapService((string) (
+            $h['service'] ?? $h['service_type'] ?? $h['fac_service'] ?? 'OTHER'
+        ));
+
+        $freq = (string) ($h['station_frequency'] ?? $h['frequency'] ?? $h['fac_frequency'] ?? '');
+        $channel = (string) ($h['channel'] ?? $h['fac_channel'] ?? '');
+
+        // For AM stations the frequency is in kHz; FM in MHz; TV uses channel.
+        $freqDisplay = match (true) {
+            str_starts_with($service, 'AM') && $freq !== '' => $freq.' kHz',
+            in_array($service, ['FM', 'LPFM']) && $freq !== '' => $freq.' MHz',
+            in_array($service, ['TV', 'LPTV']) && $channel !== '' => 'Ch. '.$channel,
+            default => $freq ?: $channel,
+        };
+
+        return [
+            'facility_id'     => (string) ($h['facility_id'] ?? $h['fac_facility_id'] ?? ''),
+            'facility_name'   => $h['fac_callsign'] ?? null,
+            'frn'             => (string) ($h['licensee_frn'] ?? $h['frn'] ?? ''),
+            'licensee'        => $h['licensee_name'] ?? $h['licensee'] ?? $h['fac_organization_name'] ?? 'Unknown',
+            'service'         => $service,
+            'frequency'       => $freqDisplay,
+            'community'       => $h['community_city'] ?? $h['fac_community_city'] ?? null,
+            'state'           => $h['community_state'] ?? $h['fac_community_state'] ?? null,
+            'expiration_date' => $h['lic_expiration_date'] ?? $h['license_expiration_date'] ?? null,
+            '_source_url'     => 'opendata.fcc.gov',
+        ];
+    }
+
+    /**
+     * Fall back to the FCC AM/FM/TV Query CGIs with format=4 (pipe-delimited).
+     * These have been the most stable FCC endpoint over the past 20 years.
+     */
+    protected function tryFccQueryCgi(string $bin, string $call): ?array
+    {
+        $url = "https://transition.fcc.gov/fcc-bin/{$bin}";
+
+        try {
+            $response = Http::timeout(15)
+                ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
+                ->get($url, ['call' => $call, 'format' => 4]);
+
+            if (! $response->ok()) return null;
+            $body = trim($response->body());
+            if ($body === '' || ! str_contains($body, '|')) return null;
+
+            // Take the first non-comment data line
+            foreach (preg_split("/\r?\n/", $body) as $line) {
+                $line = trim($line);
+                if ($line === '' || str_starts_with($line, '#') || str_starts_with($line, '*')) continue;
+                $cols = explode('|', $line);
+                if (count($cols) < 5) continue;
+
+                // FM Query format 4 columns (approximate, public docs):
+                //   call|service|status|frequency|channel|...|licensee|city|state|...|facility_id|...
+                $service = $bin === 'fmq' ? 'FM' : ($bin === 'amq' ? 'AM' : 'TV');
+                $freq = trim($cols[3] ?? '');
+                $channel = trim($cols[4] ?? '');
+                $licensee = trim($cols[6] ?? $cols[7] ?? '');
+                $city = trim($cols[8] ?? '');
+                $state = trim($cols[9] ?? '');
+
+                // Hunt for a numeric facility ID elsewhere in the row
+                $facilityId = '';
+                foreach ($cols as $c) {
+                    $c = trim($c);
+                    if (ctype_digit($c) && strlen($c) >= 4 && strlen($c) <= 7) {
+                        $facilityId = $c;
+                        break;
+                    }
+                }
+
+                $freqDisplay = $service === 'AM' ? "{$freq} kHz" : ($service === 'FM' ? "{$freq} MHz" : "Ch. {$channel}");
+
+                return [
+                    'facility_id'     => $facilityId,
+                    'facility_name'   => null,
+                    'frn'             => '',
+                    'licensee'        => $licensee ?: 'Unknown',
+                    'service'         => $service,
+                    'frequency'       => trim($freqDisplay),
+                    'community'       => $city,
+                    'state'           => $state,
+                    'expiration_date' => null,
+                    '_source_url'     => "transition.fcc.gov/fcc-bin/{$bin}",
+                ];
             }
-        }
-        if (array_is_list($payload) && ! empty($payload) && is_array($payload[0])) {
-            return $payload[0];
-        }
-        if (isset($payload['facilityId']) || isset($payload['facility_id'])) {
-            return $payload;
+        } catch (\Throwable $e) {
+            return null;
         }
 
         return null;

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -115,11 +115,23 @@ class FccImportCommand extends Command
      */
     protected function fetchFccPublicFacility(string $call): ?array
     {
-        // Strip any "-FM" / "-TV" / "-AM" suffix; FCC Query stores bare call
+        // If the user disambiguates with a suffix (e.g. WBZ-AM, KFI-AM),
+        // hit that specific query first — otherwise WBZ/KFI/etc. will
+        // match unrelated FM stations that happen to share the call.
         $bareCall = strtoupper(preg_replace('/-(FM|TV|AM|LP|LD)$/i', '', $call));
+        $suffix = '';
+        if (preg_match('/-(AM|FM|TV|LP|LD)$/i', $call, $sm)) {
+            $suffix = strtoupper($sm[1]);
+        }
 
-        // FM, then AM, then TV — first hit wins.
-        foreach (['fmq', 'amq', 'tvq'] as $bin) {
+        $order = match ($suffix) {
+            'AM'         => ['amq', 'fmq', 'tvq'],
+            'FM'         => ['fmq', 'amq', 'tvq'],
+            'TV', 'LD'   => ['tvq', 'fmq', 'amq'],
+            default      => ['fmq', 'amq', 'tvq'],
+        };
+
+        foreach ($order as $bin) {
             $hit = $this->tryFccQueryCgi($bin, $bareCall);
             if ($hit) return $hit;
         }
@@ -223,9 +235,14 @@ class FccImportCommand extends Command
             // Extract JS variable assignments. FM detail pages use bare
             // names (facility_id = '789877'), AM detail pages prefix
             // with c_ (c_facility_id = '70658', c_callsign = 'WABC').
-            // Try both forms.
+            // AM also writes some numeric fields unquoted: freq = 770;
+            // — accept both forms.
             $jsVal = function (string $name) use ($html): ?string {
-                if (preg_match("/(?<![A-Za-z0-9_])(?:c_)?{$name}\\s*=\\s*['\"]([^'\"]*)['\"]/", $html, $m)) {
+                $prefix = "(?<![A-Za-z0-9_])(?:c_)?{$name}\\s*=\\s*";
+                if (preg_match("/{$prefix}['\"]([^'\"]*)['\"]/", $html, $m)) {
+                    return trim($m[1]);
+                }
+                if (preg_match("/{$prefix}([0-9]+(?:\\.[0-9]+)?)\\s*;/", $html, $m)) {
                     return trim($m[1]);
                 }
                 return null;

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -197,32 +197,24 @@ class FccImportCommand extends Command
      */
     protected function tryFccQueryCgi(string $bin, string $call): ?array
     {
-        $url = "https://transition.fcc.gov/fcc-bin/{$bin}";
+        $html = $this->fetchFccQuery($bin, ['call' => $call, 'format' => 8]);
+        if ($html === null) return null;
 
-        try {
-            // FCC's Akamai edge blocks "Mozilla/5.0 (compatible;...)" UAs;
-            // a plain client UA (or curl/wget) passes. Use curl/X to mimic.
-            $response = Http::timeout(30)
-                ->withHeaders([
-                    'User-Agent' => 'curl/8.5.0',
-                    'Accept' => '*/*',
-                ])
-                ->get($url, ['call' => $call, 'format' => 8]);
-
-            if (! $response->ok()) {
-                if (config('app.debug')) {
-                    logger()->info("FCC {$bin} HTTP {$response->status()} for {$call}");
+        // The detail page contains JS variable assignments. The list page
+        // (returned by AM/TV Query when the call has multiple records)
+        // contains links of the form "amq?list=0&facid=70658" and the
+        // station data rendered as a single HTML row. Detect the list
+        // format and re-fetch the detail page by facility ID.
+        if (! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
+            if (preg_match('/facid=(\d+)/', $html, $m)) {
+                $html = $this->fetchFccQuery($bin, ['list' => 0, 'facid' => $m[1]]);
+                if ($html === null || ! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
+                    return null;
                 }
+            } else {
                 return null;
             }
-            $html = $response->body();
-            if ($html === '') return null;
-
-            // The page must contain at least one quoted facility_id assignment
-            // (the un-quoted "var facility_id = 0;" declaration doesn't count).
-            if (! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
-                return null;
-            }
+        }
 
             // Extract JS variable assignments that look like:
             //   facility_id = '789877';
@@ -290,21 +282,46 @@ class FccImportCommand extends Command
                 'last_license_date' => $licensedDate,
                 '_source_url'     => "transition.fcc.gov/fcc-bin/{$bin}",
             ];
-        } catch (\Throwable $e) {
-            return null;
-        }
     }
 
     protected function mapService(string $code): string
     {
+        // FCC service designators (LMS):
+        //   AM, AB (AM/AM-Booster) → AM
+        //   FM, FB (Booster), FX (Translator), FL (LPFM)
+        //   DT (Digital TV), TX (TV Translator), LD (LPTV-D), LP (LPTV-A)
+        //   CA (Class A TV), DC (Class A digital)
         $code = strtoupper(trim($code));
         return match (true) {
-            str_starts_with($code, 'AM') => 'AM',
-            str_starts_with($code, 'FM'), $code === 'FX' => 'FM',
-            str_starts_with($code, 'TV'), $code === 'DT', $code === 'DC' => 'TV',
+            in_array($code, ['AM', 'AB']) => 'AM',
+            in_array($code, ['FM', 'FB', 'FX']) => 'FM',
+            $code === 'FL' => 'LPFM',
             $code === 'LPFM' => 'LPFM',
-            $code === 'LPTV', $code === 'TX' => 'LPTV',
+            in_array($code, ['TV', 'DT', 'DC', 'CA']) => 'TV',
+            in_array($code, ['LP', 'LD', 'TX']) => 'LPTV',
             default => 'OTHER',
         };
+    }
+
+    /**
+     * Single-shot fetch from a transition.fcc.gov AM/FM/TV Query CGI.
+     * FCC's Akamai edge blocks "Mozilla/5.0 (compatible;...)" UAs; a
+     * curl/wget UA passes.
+     */
+    protected function fetchFccQuery(string $bin, array $params): ?string
+    {
+        try {
+            $response = Http::timeout(30)
+                ->withHeaders([
+                    'User-Agent' => 'curl/8.5.0',
+                    'Accept' => '*/*',
+                ])
+                ->get("https://transition.fcc.gov/fcc-bin/{$bin}", $params);
+
+            if (! $response->ok()) return null;
+            return $response->body() ?: null;
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 }

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FccFacility;
+use App\Models\FccLicense;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Pull live FCC broadcast license data from public sources.
+ *
+ * Sources:
+ *   - LMS public report API:  https://enterpriseefiling.fcc.gov/dataentry/public/tv/publicFacilitySearch.html
+ *   - CDBS daily dumps:        https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/
+ *
+ * This command is intentionally conservative: it imports a small set of
+ * stations specified by --calls=, looking each up via the FCC public
+ * facility-by-call-sign endpoint. For a full ULS / LMS bulk sync use
+ * the CDBS daily dump tables (am_eng_data, fm_eng_data, tv_eng_data,
+ * facility, application, license_filing) loaded into a separate import
+ * pipeline.
+ */
+class FccImportCommand extends Command
+{
+    protected $signature = 'fcc:import
+                            {--calls= : Comma-separated call signs to import (e.g. WABC,WTOP,KCBS-FM)}
+                            {--dry-run : Print what would be imported without writing}';
+
+    protected $description = 'Import live FCC broadcast license data for given call signs';
+
+    public function handle(): int
+    {
+        $calls = collect(explode(',', (string) $this->option('calls')))
+            ->map(fn ($c) => strtoupper(trim($c)))
+            ->filter()
+            ->unique();
+
+        if ($calls->isEmpty()) {
+            $this->error('Specify --calls=WABC,WTOP,...');
+            $this->line('');
+            $this->line('Example:');
+            $this->line('  php artisan fcc:import --calls=WABC,WTOP,KCBS-FM,WGBH-FM');
+            return self::INVALID;
+        }
+
+        $this->info('Pulling FCC public-facility data for '.$calls->count().' station(s)…');
+
+        foreach ($calls as $call) {
+            try {
+                $data = $this->fetchFccPublicFacility($call);
+                if (! $data) {
+                    $this->warn("  ✗ {$call}: not found in FCC LMS");
+                    continue;
+                }
+
+                if ($this->option('dry-run')) {
+                    $this->line("  · {$call}: {$data['licensee']} ({$data['service']} {$data['frequency']}) — facility {$data['facility_id']}");
+                    continue;
+                }
+
+                $facility = FccFacility::updateOrCreate(
+                    ['facility_id' => $data['facility_id']],
+                    [
+                        'name' => $data['facility_name'] ?? $call.' Facility',
+                        'community_of_license' => $data['community'],
+                        'state' => $data['state'],
+                        'owner' => $data['licensee'],
+                    ]
+                );
+
+                FccLicense::updateOrCreate(
+                    ['call_sign' => $call],
+                    [
+                        'frn' => $data['frn'] ?? '',
+                        'licensee' => $data['licensee'],
+                        'service' => $data['service'],
+                        'channel_or_frequency' => $data['frequency'],
+                        'expiration_date' => $data['expiration_date'] ?? null,
+                        'status' => 'active',
+                        'compliance_score' => 100.0,
+                        'facility_id' => $facility->id,
+                    ]
+                );
+
+                $this->info("  ✓ {$call}: {$data['licensee']}");
+            } catch (\Throwable $e) {
+                $this->error("  ✗ {$call}: ".$e->getMessage());
+            }
+        }
+
+        $this->line('');
+        $this->info('Done. Run `php artisan db:seed --class=FccOperationalSeeder` to add EAS/Issues-Programs/Public-File demo data for the imported stations.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Fetch one station's public facility record from the FCC LMS.
+     * Returns a normalized array or null if the station isn't found.
+     *
+     * Note: the LMS public-facility endpoint URL and response shape may
+     * change. If you need a hardened pull, drop in a CDBS bulk-data
+     * loader (the `facility`, `am/fm/tv_eng_data`, and `license_filing`
+     * tables from https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/).
+     */
+    protected function fetchFccPublicFacility(string $call): ?array
+    {
+        $url = 'https://publicfiles.fcc.gov/api/manager/station/search/'.urlencode($call).'.json';
+
+        $response = Http::timeout(10)->acceptJson()->get($url);
+        if (! $response->ok()) {
+            return null;
+        }
+
+        $payload = $response->json();
+        $hits = data_get($payload, 'stations', []);
+        if (empty($hits)) {
+            return null;
+        }
+
+        $h = $hits[0];
+
+        return [
+            'facility_id'    => (string) data_get($h, 'facilityId'),
+            'facility_name'  => data_get($h, 'transmitterName') ?? null,
+            'frn'            => data_get($h, 'frn') ?? '',
+            'licensee'       => data_get($h, 'licensee') ?? data_get($h, 'entityName', 'Unknown'),
+            'service'        => $this->mapService(data_get($h, 'serviceCode') ?? data_get($h, 'service', 'OTHER')),
+            'frequency'      => data_get($h, 'frequency') ?? data_get($h, 'channel', ''),
+            'community'      => data_get($h, 'community.city') ?? data_get($h, 'communityCity'),
+            'state'          => data_get($h, 'community.state') ?? data_get($h, 'communityState'),
+            'expiration_date'=> data_get($h, 'licenseExpirationDate'),
+        ];
+    }
+
+    protected function mapService(string $code): string
+    {
+        $code = strtoupper(trim($code));
+        return match (true) {
+            str_starts_with($code, 'AM') => 'AM',
+            str_starts_with($code, 'FM'), $code === 'FX' => 'FM',
+            str_starts_with($code, 'TV'), $code === 'DT', $code === 'DC' => 'TV',
+            $code === 'LPFM' => 'LPFM',
+            $code === 'LPTV', $code === 'TX' => 'LPTV',
+            default => 'OTHER',
+        };
+    }
+}

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -103,55 +103,40 @@ class FccImportCommand extends Command
     }
 
     /**
-     * Fetch one station's public facility record from opendata.fcc.gov.
+     * Fetch one station's public facility record.
      *
-     * The FCC publishes broadcast engineering data via the Socrata SODA
-     * API at opendata.fcc.gov — these endpoints are stable and don't
-     * require auth for low-volume queries.
+     * The FCC's old "publicfiles" and "opendata" Socrata endpoints have
+     * shifted — when last verified they returned 404. The reliable
+     * surface is the FCC's AM/FM/TV Query CGI at transition.fcc.gov,
+     * which has been live for 20+ years. We hit that directly.
      *
-     * We try the broadcast engineering dataset first, falling back to
-     * the AM/FM Query and LMS endpoints if Socrata returns nothing.
+     * If you want to wire Socrata or the LMS public API back in, drop
+     * the URL into trySocrata() and add a call below.
      */
     protected function fetchFccPublicFacility(string $call): ?array
     {
-        // Strip any "-FM" / "-TV" suffix for the search; opendata stores the bare call
+        // Strip any "-FM" / "-TV" / "-AM" suffix; FCC Query stores bare call
         $bareCall = strtoupper(preg_replace('/-(FM|TV|AM|LP|LD)$/i', '', $call));
 
-        // 1) opendata.fcc.gov — broadcast engineering (AM/FM/TV) — stable Socrata API
-        //    Dataset: "AM, FM, TV Broadcast Engineering Data" (cd28-25ar)
-        $hit = $this->trySocrata('cd28-25ar', $bareCall);
-        if ($hit) {
-            return $this->normalizeSocrata($hit);
+        // FM, then AM, then TV — first hit wins.
+        foreach (['fmq', 'amq', 'tvq'] as $bin) {
+            $hit = $this->tryFccQueryCgi($bin, $bareCall);
+            if ($hit) return $hit;
         }
-
-        // 2) opendata.fcc.gov — broadcast facility data (alt dataset)
-        $hit = $this->trySocrata('iqaq-mbpb', $bareCall);
-        if ($hit) {
-            return $this->normalizeSocrata($hit);
-        }
-
-        // 3) FCC FM Query CGI (pipe-delimited; has been stable since the 90s)
-        $hit = $this->tryFccQueryCgi('fmq', $bareCall);
-        if ($hit) return $hit;
-
-        $hit = $this->tryFccQueryCgi('amq', $bareCall);
-        if ($hit) return $hit;
-
-        $hit = $this->tryFccQueryCgi('tvq', $bareCall);
-        if ($hit) return $hit;
 
         return null;
     }
 
     /**
      * Query opendata.fcc.gov Socrata endpoint for a call sign.
+     * Currently disabled (404 as of last check) but kept for re-enabling.
      */
     protected function trySocrata(string $datasetId, string $call): ?array
     {
         $url = "https://opendata.fcc.gov/resource/{$datasetId}.json";
 
         try {
-            $response = Http::timeout(15)
+            $response = Http::timeout(8)
                 ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
                 ->acceptJson()
                 ->get($url, ['call_sign' => $call, '$limit' => 1]);

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -67,6 +67,10 @@ class FccImportCommand extends Command
                         'community_of_license' => $data['community'],
                         'state' => $data['state'],
                         'owner' => $data['licensee'],
+                        'latitude' => $data['latitude'] ?? null,
+                        'longitude' => $data['longitude'] ?? null,
+                        'antenna_haat_meters' => $data['haat_meters'] ?? null,
+                        'antenna_amsl_meters' => $data['amsl_meters'] ?? null,
                     ]
                 );
 
@@ -78,6 +82,8 @@ class FccImportCommand extends Command
                         'service' => $data['service'],
                         'channel_or_frequency' => $data['frequency'],
                         'expiration_date' => $data['expiration_date'] ?? null,
+                        'last_renewal_date' => $data['last_license_date'] ?? null,
+                        'grant_date' => $data['last_license_date'] ?? null,
                         'status' => 'active',
                         'compliance_score' => 100.0,
                         'facility_id' => $facility->id,
@@ -195,68 +201,97 @@ class FccImportCommand extends Command
     }
 
     /**
-     * Fall back to the FCC AM/FM/TV Query CGIs with format=4 (pipe-delimited).
-     * These have been the most stable FCC endpoint over the past 20 years.
+     * Fall back to the FCC AM/FM/TV Query CGIs at transition.fcc.gov.
+     *
+     * The CGI returns an HTML page containing JavaScript variable
+     * assignments with the actual record data, plus a few <b>-wrapped
+     * fields for licensee + licensed date. We parse both.
+     *
+     * URL example:
+     *   https://transition.fcc.gov/fcc-bin/fmq?call=KQED&format=8
      */
     protected function tryFccQueryCgi(string $bin, string $call): ?array
     {
         $url = "https://transition.fcc.gov/fcc-bin/{$bin}";
 
         try {
-            $response = Http::timeout(15)
+            $response = Http::timeout(20)
                 ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
-                ->get($url, ['call' => $call, 'format' => 4]);
+                ->get($url, ['call' => $call, 'format' => 8]);
 
             if (! $response->ok()) return null;
-            $body = trim($response->body());
-            if ($body === '' || ! str_contains($body, '|')) return null;
+            $html = $response->body();
+            if ($html === '' || ! str_contains($html, 'facility_id')) return null;
 
-            // Take the first non-comment data line
-            foreach (preg_split("/\r?\n/", $body) as $line) {
-                $line = trim($line);
-                if ($line === '' || str_starts_with($line, '#') || str_starts_with($line, '*')) continue;
-                $cols = explode('|', $line);
-                if (count($cols) < 5) continue;
-
-                // FM Query format 4 columns (approximate, public docs):
-                //   call|service|status|frequency|channel|...|licensee|city|state|...|facility_id|...
-                $service = $bin === 'fmq' ? 'FM' : ($bin === 'amq' ? 'AM' : 'TV');
-                $freq = trim($cols[3] ?? '');
-                $channel = trim($cols[4] ?? '');
-                $licensee = trim($cols[6] ?? $cols[7] ?? '');
-                $city = trim($cols[8] ?? '');
-                $state = trim($cols[9] ?? '');
-
-                // Hunt for a numeric facility ID elsewhere in the row
-                $facilityId = '';
-                foreach ($cols as $c) {
-                    $c = trim($c);
-                    if (ctype_digit($c) && strlen($c) >= 4 && strlen($c) <= 7) {
-                        $facilityId = $c;
-                        break;
-                    }
+            // Extract JS variable assignments that look like:
+            //   facility_id = '789877';
+            //   c_comm_city_app = "ALAMO";
+            //   freq = '88.5';
+            $jsVal = function (string $name) use ($html): ?string {
+                if (preg_match("/\\b{$name}\\s*=\\s*['\"]([^'\"]*)['\"]/", $html, $m)) {
+                    return trim($m[1]);
                 }
+                return null;
+            };
 
-                $freqDisplay = $service === 'AM' ? "{$freq} kHz" : ($service === 'FM' ? "{$freq} MHz" : "Ch. {$channel}");
+            $facilityId = $jsVal('facility_id');
+            // facility_id = 0 means "no record yet"
+            if (! $facilityId || $facilityId === '0') return null;
 
-                return [
-                    'facility_id'     => $facilityId,
-                    'facility_name'   => null,
-                    'frn'             => '',
-                    'licensee'        => $licensee ?: 'Unknown',
-                    'service'         => $service,
-                    'frequency'       => trim($freqDisplay),
-                    'community'       => $city,
-                    'state'           => $state,
-                    'expiration_date' => null,
-                    '_source_url'     => "transition.fcc.gov/fcc-bin/{$bin}",
-                ];
+            $callsign  = $jsVal('c_callsign') ?? $jsVal('c_facility_callsign') ?? $call;
+            $service   = strtoupper($jsVal('c_service') ?? '');
+            $status    = $jsVal('c_dom_status');
+            $city      = $jsVal('c_comm_city_app');
+            $state     = $jsVal('c_comm_state_app');
+            $freq      = $jsVal('freq');
+            $channel   = $jsVal('c_station_channel');
+            $erp       = $jsVal('p_erp_max');
+            $haat      = $jsVal('p_haat_max');
+            $amsl      = $jsVal('p_rcamsl_max');
+            $lat       = $jsVal('alat83');
+            $lon       = $jsVal('alon83');
+
+            // Licensee + licensed date come from HTML, not JS
+            $licensee = null;
+            if (preg_match('/Licensee:\s*<b>([^<]+)<\/b>/i', $html, $m)) {
+                $licensee = trim($m[1]);
             }
+            $licensedDate = null;
+            if (preg_match('/Licensed\s+date:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})/i', $html, $m)) {
+                $licensedDate = $m[1];
+            }
+
+            $serviceMapped = $this->mapService($service ?: ($bin === 'fmq' ? 'FM' : ($bin === 'amq' ? 'AM' : 'TV')));
+
+            $freqDisplay = match ($serviceMapped) {
+                'AM'           => $freq ? "{$freq} kHz"  : '',
+                'FM', 'LPFM'   => $freq ? "{$freq} MHz"  : '',
+                'TV', 'LPTV'   => $channel ? "Ch. {$channel}" : '',
+                default        => $freq ?: $channel ?: '',
+            };
+
+            return [
+                'facility_id'     => $facilityId,
+                'facility_name'   => $callsign,
+                'frn'             => '',
+                'licensee'        => $licensee ?: 'Unknown',
+                'service'         => $serviceMapped,
+                'frequency'       => trim($freqDisplay),
+                'community'       => $city,
+                'state'           => $state,
+                'expiration_date' => null,
+                'latitude'        => $lat ? (float) $lat : null,
+                'longitude'       => $lon ? (float) $lon : null,
+                'haat_meters'     => $haat ? (float) $haat : null,
+                'amsl_meters'     => $amsl ? (float) $amsl : null,
+                'erp_kw'          => $erp ? (float) $erp : null,
+                'license_status'  => $status,
+                'last_license_date' => $licensedDate,
+                '_source_url'     => "transition.fcc.gov/fcc-bin/{$bin}",
+            ];
         } catch (\Throwable $e) {
             return null;
         }
-
-        return null;
     }
 
     protected function mapService(string $code): string

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -200,10 +200,12 @@ class FccImportCommand extends Command
         $url = "https://transition.fcc.gov/fcc-bin/{$bin}";
 
         try {
+            // FCC's Akamai edge blocks "Mozilla/5.0 (compatible;...)" UAs;
+            // a plain client UA (or curl/wget) passes. Use curl/X to mimic.
             $response = Http::timeout(30)
                 ->withHeaders([
-                    'User-Agent' => 'Mozilla/5.0 (compatible; OpenGRC-FCC/1.0; +https://opengrc.com)',
-                    'Accept' => 'text/html,application/xhtml+xml',
+                    'User-Agent' => 'curl/8.5.0',
+                    'Accept' => '*/*',
                 ])
                 ->get($url, ['call' => $call, 'format' => 8]);
 

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -96,42 +96,97 @@ class FccImportCommand extends Command
     }
 
     /**
-     * Fetch one station's public facility record from the FCC LMS.
-     * Returns a normalized array or null if the station isn't found.
+     * Fetch one station's public facility record from the FCC.
      *
-     * Note: the LMS public-facility endpoint URL and response shape may
-     * change. If you need a hardened pull, drop in a CDBS bulk-data
-     * loader (the `facility`, `am/fm/tv_eng_data`, and `license_filing`
-     * tables from https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/).
+     * The FCC's public-search endpoints have shifted around over time.
+     * We try multiple known-good URL shapes in order. If you're hitting
+     * this in production and all fall through, the canonical fallback is
+     * a CDBS bulk-data loader (https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/).
      */
     protected function fetchFccPublicFacility(string $call): ?array
     {
-        $url = 'https://publicfiles.fcc.gov/api/manager/station/search/'.urlencode($call).'.json';
+        $candidates = [
+            // 1. Public Inspection Files manager — search by callsign query string
+            'https://publicfiles.fcc.gov/api/manager/station/search?searchString='.urlencode($call),
 
-        $response = Http::timeout(10)->acceptJson()->get($url);
-        if (! $response->ok()) {
-            return null;
-        }
+            // 2. Same site, callsign as path segment
+            'https://publicfiles.fcc.gov/api/manager/station/'.urlencode($call),
 
-        $payload = $response->json();
-        $hits = data_get($payload, 'stations', []);
-        if (empty($hits)) {
-            return null;
-        }
-
-        $h = $hits[0];
-
-        return [
-            'facility_id'    => (string) data_get($h, 'facilityId'),
-            'facility_name'  => data_get($h, 'transmitterName') ?? null,
-            'frn'            => data_get($h, 'frn') ?? '',
-            'licensee'       => data_get($h, 'licensee') ?? data_get($h, 'entityName', 'Unknown'),
-            'service'        => $this->mapService(data_get($h, 'serviceCode') ?? data_get($h, 'service', 'OTHER')),
-            'frequency'      => data_get($h, 'frequency') ?? data_get($h, 'channel', ''),
-            'community'      => data_get($h, 'community.city') ?? data_get($h, 'communityCity'),
-            'state'          => data_get($h, 'community.state') ?? data_get($h, 'communityState'),
-            'expiration_date'=> data_get($h, 'licenseExpirationDate'),
+            // 3. LMS public-facility elastic search
+            'https://enterpriseefiling.fcc.gov/dataentry/api/elasticsearch/public/api/public/facility/search?callSign='.urlencode($call),
         ];
+
+        foreach ($candidates as $url) {
+            try {
+                $response = Http::timeout(15)
+                    ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
+                    ->acceptJson()
+                    ->get($url);
+
+                if (! $response->ok()) {
+                    continue;
+                }
+
+                $payload = $response->json();
+                if (! is_array($payload) || empty($payload)) {
+                    continue;
+                }
+
+                $hit = $this->extractFirstStation($payload);
+                if (! $hit) {
+                    continue;
+                }
+
+                $facilityId = (string) data_get($hit, 'facilityId') ?: (string) data_get($hit, 'facility_id') ?: (string) data_get($hit, 'id');
+                if (! $facilityId) {
+                    continue;
+                }
+
+                return [
+                    'facility_id'     => $facilityId,
+                    'facility_name'   => data_get($hit, 'transmitterName') ?? data_get($hit, 'facilityName') ?? null,
+                    'frn'             => (string) (data_get($hit, 'frn') ?? data_get($hit, 'licenseeFrn') ?? ''),
+                    'licensee'        => data_get($hit, 'licensee') ?? data_get($hit, 'entityName') ?? data_get($hit, 'licenseeName') ?? 'Unknown',
+                    'service'         => $this->mapService((string) (data_get($hit, 'serviceCode') ?? data_get($hit, 'service') ?? 'OTHER')),
+                    'frequency'       => (string) (data_get($hit, 'frequency') ?? data_get($hit, 'channel') ?? ''),
+                    'community'       => data_get($hit, 'community.city') ?? data_get($hit, 'communityCity') ?? data_get($hit, 'communityServed.city'),
+                    'state'           => data_get($hit, 'community.state') ?? data_get($hit, 'communityState') ?? data_get($hit, 'communityServed.state'),
+                    'expiration_date' => data_get($hit, 'licenseExpirationDate') ?? data_get($hit, 'expirationDate'),
+                    '_source_url'     => $url,
+                ];
+            } catch (\Throwable $e) {
+                // try next URL
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the first station-like record from a heterogeneous payload.
+     */
+    protected function extractFirstStation(array $payload): ?array
+    {
+        // Common shapes:
+        //  - { stations: [ {...} ] }
+        //  - { hits: [ {...} ] }
+        //  - { data: [ {...} ] }
+        //  - [ {...} ]            (bare array)
+        //  - { facilityId: ... }  (single record)
+        foreach (['stations', 'hits', 'data', 'results', 'records'] as $key) {
+            if (isset($payload[$key]) && is_array($payload[$key]) && ! empty($payload[$key])) {
+                return $payload[$key][0];
+            }
+        }
+        if (array_is_list($payload) && ! empty($payload) && is_array($payload[0])) {
+            return $payload[0];
+        }
+        if (isset($payload['facilityId']) || isset($payload['facility_id'])) {
+            return $payload;
+        }
+
+        return null;
     }
 
     protected function mapService(string $code): string

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -200,13 +200,27 @@ class FccImportCommand extends Command
         $url = "https://transition.fcc.gov/fcc-bin/{$bin}";
 
         try {
-            $response = Http::timeout(20)
-                ->withHeaders(['User-Agent' => 'OpenGRC-FCC-Compliance/1.0'])
+            $response = Http::timeout(30)
+                ->withHeaders([
+                    'User-Agent' => 'Mozilla/5.0 (compatible; OpenGRC-FCC/1.0; +https://opengrc.com)',
+                    'Accept' => 'text/html,application/xhtml+xml',
+                ])
                 ->get($url, ['call' => $call, 'format' => 8]);
 
-            if (! $response->ok()) return null;
+            if (! $response->ok()) {
+                if (config('app.debug')) {
+                    logger()->info("FCC {$bin} HTTP {$response->status()} for {$call}");
+                }
+                return null;
+            }
             $html = $response->body();
-            if ($html === '' || ! str_contains($html, 'facility_id')) return null;
+            if ($html === '') return null;
+
+            // The page must contain at least one quoted facility_id assignment
+            // (the un-quoted "var facility_id = 0;" declaration doesn't count).
+            if (! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
+                return null;
+            }
 
             // Extract JS variable assignments that look like:
             //   facility_id = '789877';

--- a/app/Console/Commands/FccImportCommand.php
+++ b/app/Console/Commands/FccImportCommand.php
@@ -200,15 +200,19 @@ class FccImportCommand extends Command
         $html = $this->fetchFccQuery($bin, ['call' => $call, 'format' => 8]);
         if ($html === null) return null;
 
-        // The detail page contains JS variable assignments. The list page
-        // (returned by AM/TV Query when the call has multiple records)
-        // contains links of the form "amq?list=0&facid=70658" and the
-        // station data rendered as a single HTML row. Detect the list
-        // format and re-fetch the detail page by facility ID.
-        if (! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
+        // The detail page contains JS variable assignments (either bare
+        //   facility_id = '789877';   <- FM
+        // or
+        //   c_facility_id = '70658';  <- AM
+        // ). The list page (returned by AM/TV Query for multi-record
+        // calls) carries facid=NNNN links instead. If we got a list page,
+        // re-fetch the detail page by facility ID.
+        $hasDetail = preg_match("/(?<![A-Za-z0-9_])(?:c_)?facility_id\s*=\s*['\"][1-9]/", $html);
+        if (! $hasDetail) {
             if (preg_match('/facid=(\d+)/', $html, $m)) {
                 $html = $this->fetchFccQuery($bin, ['list' => 0, 'facid' => $m[1]]);
-                if ($html === null || ! preg_match("/facility_id\s*=\s*['\"][1-9]/", $html)) {
+                if ($html === null) return null;
+                if (! preg_match("/(?<![A-Za-z0-9_])(?:c_)?facility_id\s*=\s*['\"][1-9]/", $html)) {
                     return null;
                 }
             } else {
@@ -216,12 +220,12 @@ class FccImportCommand extends Command
             }
         }
 
-            // Extract JS variable assignments that look like:
-            //   facility_id = '789877';
-            //   c_comm_city_app = "ALAMO";
-            //   freq = '88.5';
+            // Extract JS variable assignments. FM detail pages use bare
+            // names (facility_id = '789877'), AM detail pages prefix
+            // with c_ (c_facility_id = '70658', c_callsign = 'WABC').
+            // Try both forms.
             $jsVal = function (string $name) use ($html): ?string {
-                if (preg_match("/\\b{$name}\\s*=\\s*['\"]([^'\"]*)['\"]/", $html, $m)) {
+                if (preg_match("/(?<![A-Za-z0-9_])(?:c_)?{$name}\\s*=\\s*['\"]([^'\"]*)['\"]/", $html, $m)) {
                     return trim($m[1]);
                 }
                 return null;

--- a/app/Console/Commands/FccImportLmsCommand.php
+++ b/app/Console/Commands/FccImportLmsCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FccLicense;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * LMS augmentation pass — fills FRN (FCC Registration Number) and
+ * other LMS-only fields onto licenses already imported from CDBS.
+ *
+ * Source:
+ *   https://enterpriseefiling.fcc.gov/dataentry/public/tv/publicFacilityDetails.html?facilityId={id}
+ *
+ * The FCC's modern LMS public facility-details page exposes FRN +
+ * facility status + status date + title (full station name) per
+ * facility. CDBS bulk dumps don't include FRN, so we have to scrape
+ * LMS one facility at a time. We rate-limit to be polite and keep
+ * the run resumable.
+ *
+ * Usage:
+ *   php artisan fcc:import-lms                  # all licenses missing FRN
+ *   php artisan fcc:import-lms --limit=200      # batch
+ *   php artisan fcc:import-lms --calls=KQED,WTOP # specific stations
+ *   php artisan fcc:import-lms --sleep=300      # 300ms between requests
+ */
+class FccImportLmsCommand extends Command
+{
+    protected $signature = 'fcc:import-lms
+                            {--limit= : Cap the number of stations augmented this run}
+                            {--calls= : Comma-separated call signs (skips the missing-FRN filter)}
+                            {--sleep=200 : Delay (ms) between FCC requests}
+                            {--force : Re-fetch even if FRN already populated}';
+
+    protected $description = 'Augment imported licenses with FRN + LMS facility details';
+
+    private const LMS_DETAIL = 'https://enterpriseefiling.fcc.gov/dataentry/public/tv/publicFacilityDetails.html';
+
+    public function handle(): int
+    {
+        $sleepMs = (int) $this->option('sleep');
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+
+        $query = FccLicense::query()->with('facility');
+
+        if ($calls = $this->option('calls')) {
+            $list = collect(explode(',', $calls))->map(fn ($c) => strtoupper(trim($c)))->filter()->all();
+            $query->whereIn('call_sign', $list);
+        } elseif (! $this->option('force')) {
+            $query->where(function ($q) {
+                $q->whereNull('frn')->orWhere('frn', '')->orWhere('frn', 'like', 'Pending%');
+            });
+        }
+
+        if ($limit) $query->limit($limit);
+
+        $total = (clone $query)->count();
+        if ($total === 0) {
+            $this->info('Nothing to augment — all targeted licenses already have an FRN.');
+            return self::SUCCESS;
+        }
+
+        $this->info("LMS augmentation — {$total} licenses to fetch (rate-limited)…");
+        $progress = $this->output->createProgressBar($total);
+        $progress->setFormat(' %current%/%max% [%bar%] %percent:3s%%  %message%');
+        $progress->setMessage('');
+        $progress->start();
+
+        $hits = 0;
+        $misses = 0;
+
+        $query->chunk(200, function ($chunk) use (&$hits, &$misses, $progress, $sleepMs) {
+            foreach ($chunk as $license) {
+                $facilityId = optional($license->facility)->facility_id;
+                if (! $facilityId) {
+                    $progress->advance();
+                    continue;
+                }
+
+                $data = $this->fetchLmsFacility($facilityId);
+                $progress->setMessage($license->call_sign);
+                $progress->advance();
+
+                if (! $data) { $misses++; continue; }
+
+                $updates = [];
+                if (! empty($data['frn'])) {
+                    $updates['frn'] = $data['frn'];
+                }
+                if ($updates) {
+                    DB::table('fcc_licenses')->where('id', $license->id)->update($updates);
+                    $hits++;
+                }
+                if (! empty($data['title']) || ! empty($data['status_date'])) {
+                    $facUpdates = [];
+                    if (! empty($data['title']) && empty($license->facility->name)) {
+                        $facUpdates['name'] = $data['title'];
+                    }
+                    if ($facUpdates) {
+                        DB::table('fcc_facilities')->where('id', $license->facility->id)->update($facUpdates);
+                    }
+                }
+
+                if ($sleepMs > 0) usleep($sleepMs * 1000);
+            }
+        });
+
+        $progress->finish();
+        $this->newLine(2);
+        $this->info("Updated FRN on {$hits} licenses ({$misses} misses).");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Scrape one LMS facility-details page. Returns a normalized array
+     * of LMS-only fields (FRN, title, status date, facility status).
+     */
+    protected function fetchLmsFacility(string $facilityId): ?array
+    {
+        try {
+            $response = Http::timeout(20)
+                ->withHeaders([
+                    'User-Agent' => 'curl/8.5.0',
+                    'Accept' => 'text/html,application/xhtml+xml',
+                ])
+                ->get(self::LMS_DETAIL, ['facilityId' => $facilityId]);
+
+            if (! $response->ok()) return null;
+            $html = $response->body();
+            if ($html === '' || ! str_contains($html, 'FRN')) return null;
+
+            return [
+                'frn'           => $this->dtdd($html, 'FRN'),
+                'title'         => $this->dtdd($html, 'Title'),
+                'name'          => $this->dtdd($html, 'Name'),
+                'service'       => $this->dtdd($html, 'Service'),
+                'status'        => $this->dtdd($html, 'Facility Status'),
+                'status_date'   => $this->dtdd($html, 'Status Date'),
+                'facility_type' => $this->dtdd($html, 'Facility Type'),
+                'station_type'  => $this->dtdd($html, 'Station Type'),
+                'community'     => $this->dtdd($html, 'Community'),
+                'frequency'     => $this->dtdd($html, 'Frequency'),
+                'digital_op'    => $this->dtdd($html, 'Digital Operation'),
+                'email'         => $this->dtdd($html, 'Email'),
+                'phone'         => $this->dtdd($html, 'Phone'),
+                'address'       => $this->dtdd($html, 'Address'),
+                'country'       => $this->dtdd($html, 'Country'),
+            ];
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Pull the value from a <dt>Label:</dt> <dd>value</dd> pair.
+     */
+    private function dtdd(string $html, string $label): ?string
+    {
+        $pattern = '/<dt>'.preg_quote($label, '/').':<\/dt>\s*<dd[^>]*>([^<]+)<\/dd>/i';
+        if (preg_match($pattern, $html, $m)) {
+            return trim(html_entity_decode($m[1], ENT_QUOTES | ENT_HTML5));
+        }
+        return null;
+    }
+}

--- a/app/Console/Commands/FccImportLmsCommand.php
+++ b/app/Console/Commands/FccImportLmsCommand.php
@@ -56,7 +56,11 @@ class FccImportLmsCommand extends Command
 
         if ($limit) $query->limit($limit);
 
-        $total = (clone $query)->count();
+        // Eloquent's chunk() ignores prior limit() calls, so eager-load
+        // the capped result set instead. For 1k-row batches this fits
+        // easily in memory.
+        $licenses = $query->get();
+        $total = $licenses->count();
         if ($total === 0) {
             $this->info('Nothing to augment — all targeted licenses already have an FRN.');
             return self::SUCCESS;
@@ -71,8 +75,7 @@ class FccImportLmsCommand extends Command
         $hits = 0;
         $misses = 0;
 
-        $query->chunk(200, function ($chunk) use (&$hits, &$misses, $progress, $sleepMs) {
-            foreach ($chunk as $license) {
+        foreach ($licenses as $license) {
                 $facilityId = optional($license->facility)->facility_id;
                 if (! $facilityId) {
                     $progress->advance();
@@ -104,8 +107,7 @@ class FccImportLmsCommand extends Command
                 }
 
                 if ($sleepMs > 0) usleep($sleepMs * 1000);
-            }
-        });
+        }
 
         $progress->finish();
         $this->newLine(2);

--- a/app/Console/Commands/FccSyncCommand.php
+++ b/app/Console/Commands/FccSyncCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Master FCC sync — runs the full data pipeline end-to-end:
+ *
+ *   1. fcc:import-bulk  → every U.S. broadcast facility + license
+ *      (CDBS facility.zip + am/fm/tv_eng_data.zip + party.zip)
+ *
+ *   2. fcc:import-asr   → every Antenna Structure Registration
+ *      (data.fcc.gov ULS r_tower.zip + a_tower.zip)
+ *
+ *   3. db:seed FccOperationalSeeder → realistic operational data
+ *      (EAS tests, Issues/Programs lists, public file documents,
+ *       tower lighting inspections, political file, station log,
+ *       regulatory fees, form filings) for the imported stations.
+ *
+ * This is the command an operator runs after deploying the FCC reskin
+ * to populate every page in the app with real data.
+ *
+ * Usage:
+ *   php artisan fcc:sync
+ *   php artisan fcc:sync --quick      # smoke test (--limit=200, no licensees)
+ *   php artisan fcc:sync --skip-asr   # skip ASR import (faster)
+ *   php artisan fcc:sync --skip-bulk  # skip CDBS bulk (use existing data)
+ */
+class FccSyncCommand extends Command
+{
+    protected $signature = 'fcc:sync
+                            {--quick : Smoke test (limit=200 per service, no licensee names)}
+                            {--skip-bulk : Skip the CDBS bulk import}
+                            {--skip-asr : Skip the ASR bulk import}
+                            {--skip-operational : Skip generating EAS/IPL/etc demo data}';
+
+    protected $description = 'Run the full FCC data pipeline (bulk + ASR + operational)';
+
+    public function handle(): int
+    {
+        $this->info('═══════════════════════════════════════════════════');
+        $this->info('  OpenGRC FCC Compliance — Full Data Sync');
+        $this->info('═══════════════════════════════════════════════════');
+        $this->newLine();
+
+        $quick = $this->option('quick');
+
+        if (! $this->option('skip-bulk')) {
+            $this->info('▶ Step 1/3: CDBS bulk import (every U.S. broadcast station)');
+            $bulkOpts = ['--no-interaction' => true];
+            if ($quick) {
+                $bulkOpts['--limit'] = 200;
+                $bulkOpts['--skip-licensees'] = true;
+            }
+            $exit = $this->call('fcc:import-bulk', $bulkOpts);
+            if ($exit !== 0) {
+                $this->error('  CDBS bulk import failed; aborting');
+                return $exit;
+            }
+            $this->newLine();
+        }
+
+        if (! $this->option('skip-asr')) {
+            $this->info('▶ Step 2/3: ASR bulk import (Antenna Structure Registrations)');
+            $asrOpts = ['--no-interaction' => true];
+            if ($quick) $asrOpts['--limit'] = 200;
+            $exit = $this->call('fcc:import-asr', $asrOpts);
+            if ($exit !== 0) {
+                $this->warn('  ASR import returned non-zero; continuing');
+            }
+            $this->newLine();
+        }
+
+        if (! $this->option('skip-operational')) {
+            $this->info('▶ Step 3/3: Operational data (EAS tests / IPL / Public File / etc.)');
+            $exit = $this->call('db:seed', [
+                '--class' => 'Database\\Seeders\\FccOperationalSeeder',
+                '--force' => true,
+                '--no-interaction' => true,
+            ]);
+            if ($exit !== 0) {
+                $this->warn('  Operational seeder returned non-zero; continuing');
+            }
+            $this->newLine();
+        }
+
+        $this->info('═══════════════════════════════════════════════════');
+        $this->info('  Sync complete. Hard-refresh /app/dashboard');
+        $this->info('═══════════════════════════════════════════════════');
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/FccSyncCommand.php
+++ b/app/Console/Commands/FccSyncCommand.php
@@ -33,6 +33,8 @@ class FccSyncCommand extends Command
                             {--quick : Smoke test (limit=200 per service, no licensee names)}
                             {--skip-bulk : Skip the CDBS bulk import}
                             {--skip-asr : Skip the ASR bulk import}
+                            {--skip-lms : Skip the LMS FRN augmentation pass}
+                            {--lms-batch=1000 : LMS augmentation batch size per run}
                             {--skip-operational : Skip generating EAS/IPL/etc demo data}';
 
     protected $description = 'Run the full FCC data pipeline (bulk + ASR + operational)';
@@ -62,7 +64,7 @@ class FccSyncCommand extends Command
         }
 
         if (! $this->option('skip-asr')) {
-            $this->info('▶ Step 2/3: ASR bulk import (Antenna Structure Registrations)');
+            $this->info('▶ Step 2/4: ASR bulk import (Antenna Structure Registrations)');
             $asrOpts = ['--no-interaction' => true];
             if ($quick) $asrOpts['--limit'] = 200;
             $exit = $this->call('fcc:import-asr', $asrOpts);
@@ -72,8 +74,22 @@ class FccSyncCommand extends Command
             $this->newLine();
         }
 
+        if (! $this->option('skip-lms')) {
+            $this->info('▶ Step 3/4: LMS augmentation (per-station FRN, polite + resumable)');
+            $batch = $quick ? 50 : (int) $this->option('lms-batch');
+            $exit = $this->call('fcc:import-lms', [
+                '--limit' => $batch,
+                '--no-interaction' => true,
+            ]);
+            if ($exit !== 0) {
+                $this->warn('  LMS augmentation returned non-zero; continuing');
+            }
+            $this->line("  Re-run `php artisan fcc:import-lms` to continue augmenting more stations.");
+            $this->newLine();
+        }
+
         if (! $this->option('skip-operational')) {
-            $this->info('▶ Step 3/3: Operational data (EAS tests / IPL / Public File / etc.)');
+            $this->info('▶ Step 4/4: Operational data (EAS tests / IPL / Public File / etc.)');
             $exit = $this->call('db:seed', [
                 '--class' => 'Database\\Seeders\\FccOperationalSeeder',
                 '--force' => true,

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -25,8 +25,14 @@ class Dashboard extends Page
 
     protected function getViewData(): array
     {
+        // Cap at 25 for the dashboard table; the full list is one click
+        // away on /app/fcc-licenses. After fcc:import-bulk we may have
+        // ~30K stations, so unbounded ::get() would render 30K <tr>s.
+        $totalLicenses = FccLicense::query()->count();
         $licenses = FccLicense::query()
+            ->orderByRaw("CASE status WHEN 'non_compliant' THEN 0 WHEN 'at_risk' THEN 1 WHEN 'expiring_soon' THEN 2 ELSE 3 END")
             ->orderBy('call_sign')
+            ->limit(25)
             ->get();
 
         $statusCounts = FccLicenseRuleStatus::query()
@@ -87,7 +93,7 @@ class Dashboard extends Page
 
         return [
             'licenses' => $licenses,
-            'totalLicenses' => $licenses->count(),
+            'totalLicenses' => $totalLicenses,
             'totalRules' => $compliant + $atRisk + $nonCompliant,
             'compliant' => $compliant,
             'atRisk' => $atRisk,

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -20,7 +20,7 @@ class Dashboard extends BaseDashboard
 
     protected static ?int $navigationSort = -2;
 
-    public function getColumns(): int|string|array
+    public function getColumns(): int|array
     {
         return 2;
     }

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -2,11 +2,12 @@
 
 namespace App\Filament\Pages;
 
-use App\Filament\Widgets\AuditListWidget;
-use App\Filament\Widgets\ControlsStatsWidget;
-use App\Filament\Widgets\ImplementationsStatsWidget;
-use App\Filament\Widgets\StatsOverview;
-use App\Filament\Widgets\ToDoListWidget;
+use App\Filament\Widgets\FccComplianceActivityWidget;
+use App\Filament\Widgets\FccComplianceOverviewWidget;
+use App\Filament\Widgets\FccLicenseComplianceTableWidget;
+use App\Filament\Widgets\FccRuleCategoryRollupWidget;
+use App\Filament\Widgets\FccTopNonCompliantRulesWidget;
+use App\Filament\Widgets\FccUpcomingDeadlinesWidget;
 
 class Dashboard extends TabbedPage
 {
@@ -14,23 +15,30 @@ class Dashboard extends TabbedPage
 
     protected static ?string $navigationLabel = 'Dashboard';
 
-    protected static ?string $title = 'Dashboard';
+    protected static ?string $title = 'Compliance at a Glance';
 
     protected static ?int $navigationSort = -2;
+
+    public function getStatsWidgets(): array
+    {
+        return [
+            FccComplianceOverviewWidget::class,
+        ];
+    }
 
     public function getWidgets(): array
     {
         return [
-            StatsOverview::class,
-            ControlsStatsWidget::class,
-            AuditListWidget::class,
-            ImplementationsStatsWidget::class,
-            ToDoListWidget::class,
+            FccLicenseComplianceTableWidget::class,
+            FccRuleCategoryRollupWidget::class,
+            FccTopNonCompliantRulesWidget::class,
+            FccUpcomingDeadlinesWidget::class,
+            FccComplianceActivityWidget::class,
         ];
     }
 
     public function getColumns(): int|string|array
     {
-        return 3;
+        return 2;
     }
 }

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -8,8 +8,9 @@ use App\Filament\Widgets\FccLicenseComplianceTableWidget;
 use App\Filament\Widgets\FccRuleCategoryRollupWidget;
 use App\Filament\Widgets\FccTopNonCompliantRulesWidget;
 use App\Filament\Widgets\FccUpcomingDeadlinesWidget;
+use Filament\Pages\Dashboard as BaseDashboard;
 
-class Dashboard extends TabbedPage
+class Dashboard extends BaseDashboard
 {
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-home';
 
@@ -19,26 +20,20 @@ class Dashboard extends TabbedPage
 
     protected static ?int $navigationSort = -2;
 
-    public function getStatsWidgets(): array
+    public function getColumns(): int|string|array
     {
-        return [
-            FccComplianceOverviewWidget::class,
-        ];
+        return 2;
     }
 
     public function getWidgets(): array
     {
         return [
+            FccComplianceOverviewWidget::class,
             FccLicenseComplianceTableWidget::class,
             FccRuleCategoryRollupWidget::class,
             FccTopNonCompliantRulesWidget::class,
             FccUpcomingDeadlinesWidget::class,
             FccComplianceActivityWidget::class,
         ];
-    }
-
-    public function getColumns(): int|string|array
-    {
-        return 2;
     }
 }

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -2,15 +2,14 @@
 
 namespace App\Filament\Pages;
 
-use App\Filament\Widgets\FccComplianceActivityWidget;
-use App\Filament\Widgets\FccComplianceOverviewWidget;
-use App\Filament\Widgets\FccLicenseComplianceTableWidget;
-use App\Filament\Widgets\FccRuleCategoryRollupWidget;
-use App\Filament\Widgets\FccTopNonCompliantRulesWidget;
-use App\Filament\Widgets\FccUpcomingDeadlinesWidget;
-use Filament\Pages\Dashboard as BaseDashboard;
+use App\Models\FccComplianceEvent;
+use App\Models\FccDeadline;
+use App\Models\FccLicense;
+use App\Models\FccLicenseRuleStatus;
+use App\Models\FccRule;
+use Filament\Pages\Page;
 
-class Dashboard extends BaseDashboard
+class Dashboard extends Page
 {
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-home';
 
@@ -20,20 +19,100 @@ class Dashboard extends BaseDashboard
 
     protected static ?int $navigationSort = -2;
 
-    public function getColumns(): int|array
+    protected static ?string $slug = 'dashboard';
+
+    protected string $view = 'filament.pages.fcc-dashboard';
+
+    protected function getViewData(): array
     {
-        return 2;
+        $licenses = FccLicense::query()
+            ->orderBy('call_sign')
+            ->get();
+
+        $statusCounts = FccLicenseRuleStatus::query()
+            ->selectRaw('status, COUNT(*) as c')
+            ->groupBy('status')
+            ->pluck('c', 'status')
+            ->toArray();
+
+        $compliant = (int) ($statusCounts['compliant'] ?? 0);
+        $atRisk = (int) ($statusCounts['at_risk'] ?? 0);
+        $nonCompliant = (int) ($statusCounts['non_compliant'] ?? 0);
+        $totalRules = max(1, $compliant + $atRisk + $nonCompliant);
+        $overallPct = round(($compliant / $totalRules) * 100, 1);
+
+        $categoryRows = collect();
+        $byCat = FccRule::query()->get()->groupBy('category');
+        foreach ($byCat as $category => $rules) {
+            $ids = $rules->pluck('id');
+            $cs = FccLicenseRuleStatus::query()
+                ->whereIn('fcc_rule_id', $ids)
+                ->selectRaw('status, COUNT(*) as c')
+                ->groupBy('status')
+                ->pluck('c', 'status');
+
+            $c = (int) ($cs['compliant'] ?? 0);
+            $a = (int) ($cs['at_risk'] ?? 0);
+            $n = (int) ($cs['non_compliant'] ?? 0);
+            $tot = max(1, $c + $a + $n);
+            $categoryRows->push([
+                'label' => $this->formatCategory($category),
+                'compliant' => $c,
+                'at_risk' => $a,
+                'non_compliant' => $n,
+                'percent' => round(($c / $tot) * 100, 1),
+            ]);
+        }
+        $categoryRows = $categoryRows->sortByDesc('compliant')->values();
+
+        $topNonCompliant = FccRule::query()
+            ->whereHas('statuses', fn ($q) => $q->whereIn('status', ['non_compliant', 'at_risk']))
+            ->withCount([
+                'statuses as affected_count' => fn ($q) => $q->whereIn('status', ['non_compliant', 'at_risk']),
+            ])
+            ->orderByDesc('affected_count')
+            ->limit(5)
+            ->get();
+
+        $deadlines = FccDeadline::query()
+            ->whereIn('status', ['upcoming', 'due_soon', 'overdue'])
+            ->orderBy('due_date')
+            ->limit(6)
+            ->get();
+
+        $activity = FccComplianceEvent::query()
+            ->orderByDesc('occurred_at')
+            ->limit(6)
+            ->get();
+
+        return [
+            'licenses' => $licenses,
+            'totalLicenses' => $licenses->count(),
+            'totalRules' => $compliant + $atRisk + $nonCompliant,
+            'compliant' => $compliant,
+            'atRisk' => $atRisk,
+            'nonCompliant' => $nonCompliant,
+            'overallPct' => $overallPct,
+            'categoryRows' => $categoryRows,
+            'totalCompliantPct' => $overallPct,
+            'totalAtRiskPct' => round(($atRisk / $totalRules) * 100, 1),
+            'totalNonPct' => round(($nonCompliant / $totalRules) * 100, 1),
+            'topNonCompliant' => $topNonCompliant,
+            'deadlines' => $deadlines,
+            'activity' => $activity,
+        ];
     }
 
-    public function getWidgets(): array
+    private function formatCategory(string $key): string
     {
-        return [
-            FccComplianceOverviewWidget::class,
-            FccLicenseComplianceTableWidget::class,
-            FccRuleCategoryRollupWidget::class,
-            FccTopNonCompliantRulesWidget::class,
-            FccUpcomingDeadlinesWidget::class,
-            FccComplianceActivityWidget::class,
-        ];
+        return match ($key) {
+            'technical_standards' => 'Technical Standards',
+            'operational_rules' => 'Operational Rules',
+            'eas_requirements' => 'EAS Requirements',
+            'public_file_rules' => 'Public File Rules',
+            'ownership_control' => 'Ownership / Control',
+            'reporting_requirements' => 'Reporting Requirements',
+            default => str($key)->headline()->toString(),
+        };
     }
 }

--- a/app/Filament/Resources/FccAsrRegistrationResource.php
+++ b/app/Filament/Resources/FccAsrRegistrationResource.php
@@ -72,7 +72,10 @@ class FccAsrRegistrationResource extends Resource
             TextColumn::make('lighting_type')->badge(),
             TextColumn::make('next_inspection_due')->date('M d, Y')->label('Next Inspection')
                 ->color(fn ($state) => $state && $state < now()->addDays(30) ? 'danger' : 'success'),
-        ])->defaultSort('asr_number');
+        ])
+        ->defaultSort('asr_number')
+        ->striped()
+        ->paginated([25, 50, 100, 250]);
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FccAsrRegistrationResource.php
+++ b/app/Filament/Resources/FccAsrRegistrationResource.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccAsrRegistrationResource\Pages\ManageFccAsrRegistrations;
+use App\Models\FccAsrRegistration;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FccAsrRegistrationResource extends Resource
+{
+    protected static ?string $model = FccAsrRegistration::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-radio';
+
+    protected static ?string $navigationLabel = 'ASR Registrations';
+
+    protected static ?string $modelLabel = 'ASR (Antenna Structure Reg.)';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 90;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('asr_number')->required()->unique(ignoreRecord: true)
+                ->placeholder('7-digit FCC ASR #')
+                ->helperText('47 CFR Part 17'),
+            TextInput::make('owner')->required(),
+            Select::make('structure_type')->options([
+                'guyed' => 'Guyed Tower',
+                'self_supporting' => 'Self-Supporting',
+                'monopole' => 'Monopole',
+                'building' => 'Building / Roof Mount',
+                'pole' => 'Pole',
+            ]),
+            TextInput::make('overall_height_meters')->numeric()->label('Overall Height (m)')
+                ->helperText('AGL — registration required >60.96m (200ft)'),
+            TextInput::make('latitude')->numeric(),
+            TextInput::make('longitude')->numeric(),
+            TextInput::make('faa_study_number')->label('FAA Study #'),
+            Select::make('lighting_type')->options([
+                'none' => 'None',
+                'red_only' => 'Red beacon only (FAA Style A)',
+                'medium_dual' => 'Medium-intensity Dual',
+                'high_dual' => 'High-intensity Dual',
+                'medium_white' => 'Medium-intensity White',
+                'high_white' => 'High-intensity White',
+            ]),
+            Select::make('painting_required')->options([
+                'none' => 'None',
+                'aviation_orange_white' => 'Aviation Orange / White (Std 1)',
+            ]),
+            DatePicker::make('last_inspection_date')->label('Last §17.47 Inspection'),
+            DatePicker::make('next_inspection_due')->label('Next Inspection Due'),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('asr_number')->label('ASR #')->weight('bold')->searchable()->sortable(),
+            TextColumn::make('owner')->searchable()->limit(28),
+            TextColumn::make('structure_type')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('overall_height_meters')->label('Height (m)')->numeric(2),
+            TextColumn::make('lighting_type')->badge(),
+            TextColumn::make('next_inspection_due')->date('M d, Y')->label('Next Inspection')
+                ->color(fn ($state) => $state && $state < now()->addDays(30) ? 'danger' : 'success'),
+        ])->defaultSort('asr_number');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccAsrRegistrations::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccAsrRegistrationResource/Pages/ManageFccAsrRegistrations.php
+++ b/app/Filament/Resources/FccAsrRegistrationResource/Pages/ManageFccAsrRegistrations.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccAsrRegistrationResource\Pages;
+
+use App\Filament\Resources\FccAsrRegistrationResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccAsrRegistrations extends ManageRecords
+{
+    protected static string $resource = FccAsrRegistrationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccDeadlineResource.php
+++ b/app/Filament/Resources/FccDeadlineResource.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccDeadlineResource\Pages\ManageFccDeadlines;
+use App\Models\FccDeadline;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccDeadlineResource extends Resource
+{
+    protected static ?string $model = FccDeadline::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-calendar-days';
+
+    protected static ?string $navigationLabel = 'Deadlines';
+
+    protected static ?string $modelLabel = 'FCC Deadline';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 60;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('title')->required()->columnSpanFull(),
+            Select::make('license_id')->relationship('license', 'call_sign')->searchable()
+                ->label('License (optional)'),
+            Select::make('deadline_type')->required()->options([
+                'quarterly_eas_test' => 'Quarterly EAS Test Filing',
+                'public_file_upload' => 'Public File Upload',
+                'license_renewal' => 'License Renewal',
+                'issues_programs_list' => 'Issues/Programs List',
+                'ownership_report' => 'Biennial Ownership Report (Form 323)',
+                'eeo_report' => 'EEO Public File Report',
+                'children_tv_report' => "Children's TV Report (Form 2100-H)",
+                'tower_lighting' => 'Tower Lighting Inspection',
+                'other' => 'Other',
+            ]),
+            DatePicker::make('due_date')->required(),
+            Select::make('status')->required()->options([
+                'upcoming' => 'Upcoming',
+                'due_soon' => 'Due Soon',
+                'overdue' => 'Overdue',
+                'completed' => 'Completed',
+            ])->default('upcoming'),
+            Textarea::make('notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('due_date')->date('M d, Y')->sortable(),
+            TextColumn::make('title')->searchable()->weight('bold')->limit(40),
+            TextColumn::make('deadline_type')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('license.call_sign')->label('Call Sign')->searchable(),
+            TextColumn::make('status')->badge()->color(fn ($s) => match ($s) {
+                'upcoming' => 'gray', 'due_soon' => 'warning',
+                'overdue' => 'danger', 'completed' => 'success', default => 'gray',
+            })->formatStateUsing(fn ($s) => str($s)->headline()),
+        ])->filters([
+            SelectFilter::make('deadline_type')->options([
+                'quarterly_eas_test' => 'Quarterly EAS Test',
+                'public_file_upload' => 'Public File Upload',
+                'license_renewal' => 'License Renewal',
+                'issues_programs_list' => 'Issues/Programs List',
+            ]),
+            SelectFilter::make('status')->options([
+                'upcoming' => 'Upcoming', 'due_soon' => 'Due Soon',
+                'overdue' => 'Overdue', 'completed' => 'Completed',
+            ]),
+        ])->defaultSort('due_date');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ManageFccDeadlines::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccDeadlineResource.php
+++ b/app/Filament/Resources/FccDeadlineResource.php
@@ -81,6 +81,11 @@ class FccDeadlineResource extends Resource
         ])->defaultSort('due_date');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/FccDeadlineResource/Pages/ManageFccDeadlines.php
+++ b/app/Filament/Resources/FccDeadlineResource/Pages/ManageFccDeadlines.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccDeadlineResource\Pages;
+
+use App\Filament\Resources\FccDeadlineResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccDeadlines extends ManageRecords
+{
+    protected static string $resource = FccDeadlineResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccEasTestResource.php
+++ b/app/Filament/Resources/FccEasTestResource.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccEasTestResource\Pages\ManageFccEasTests;
+use App\Models\FccEasTest;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccEasTestResource extends Resource
+{
+    protected static ?string $model = FccEasTest::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-shield-check';
+
+    protected static ?string $navigationLabel = 'EAS Tests';
+
+    protected static ?string $modelLabel = 'EAS Test';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 70;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable()->preload(),
+            Select::make('test_type')->required()->options([
+                'RWT' => 'RWT — Required Weekly Test',
+                'RMT' => 'RMT — Required Monthly Test',
+                'NPT' => 'NPT — National Periodic Test',
+                'state_test' => 'State EAS Test',
+            ])->helperText('Per 47 CFR Part 11'),
+            Select::make('direction')->required()->options([
+                'received' => 'Received (from monitor)',
+                'originated' => 'Originated (this station)',
+            ])->default('received'),
+            DateTimePicker::make('test_datetime')->required()->seconds(false),
+            TextInput::make('originator_code')->maxLength(8)
+                ->helperText('e.g. EAN, PEP, EAS, CIV, WXR'),
+            TextInput::make('event_code')->maxLength(8)
+                ->helperText('e.g. RWT, RMT, EAS, EAN, NPT'),
+            TextInput::make('location_codes')->helperText('FIPS codes (comma-separated)'),
+            Toggle::make('audio_intelligible')->default(true),
+            Toggle::make('visual_message_present')->default(true),
+            Toggle::make('filed_in_etrs')->label('Filed in FCC ETRS'),
+            TextInput::make('logged_by')->placeholder('Operator name'),
+            Textarea::make('comments')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('test_datetime')->dateTime('M d, Y H:i')->sortable()->label('Date/Time'),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('test_type')->badge()->color(fn ($s) => match ($s) {
+                'RWT' => 'gray', 'RMT' => 'info', 'NPT' => 'warning',
+                'state_test' => 'info', default => 'gray',
+            }),
+            TextColumn::make('direction')->badge()->color(fn ($s) => $s === 'originated' ? 'success' : 'gray'),
+            TextColumn::make('event_code'),
+            TextColumn::make('originator_code'),
+            IconColumn::make('audio_intelligible')->boolean()->label('Audio'),
+            IconColumn::make('filed_in_etrs')->boolean()->label('ETRS'),
+            TextColumn::make('logged_by')->toggleable(),
+        ])->filters([
+            SelectFilter::make('test_type')->options([
+                'RWT' => 'RWT', 'RMT' => 'RMT', 'NPT' => 'NPT', 'state_test' => 'State',
+            ]),
+            SelectFilter::make('license_id')->relationship('license', 'call_sign')->label('Call Sign'),
+        ])->defaultSort('test_datetime', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccEasTests::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccEasTestResource.php
+++ b/app/Filament/Resources/FccEasTestResource.php
@@ -33,7 +33,7 @@ class FccEasTestResource extends Resource
     public static function form(Schema $schema): Schema
     {
         return $schema->components([
-            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable()->preload(),
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
             Select::make('test_type')->required()->options([
                 'RWT' => 'RWT — Required Weekly Test',
                 'RMT' => 'RMT — Required Monthly Test',
@@ -79,6 +79,11 @@ class FccEasTestResource extends Resource
             ]),
             SelectFilter::make('license_id')->relationship('license', 'call_sign')->label('Call Sign'),
         ])->defaultSort('test_datetime', 'desc');
+    }
+
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FccEasTestResource/Pages/ManageFccEasTests.php
+++ b/app/Filament/Resources/FccEasTestResource/Pages/ManageFccEasTests.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccEasTestResource\Pages;
+
+use App\Filament\Resources\FccEasTestResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccEasTests extends ManageRecords
+{
+    protected static string $resource = FccEasTestResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccFacilityResource.php
+++ b/app/Filament/Resources/FccFacilityResource.php
@@ -46,14 +46,19 @@ class FccFacilityResource extends Resource
     public static function table(Table $table): Table
     {
         return $table->columns([
-            TextColumn::make('facility_id')->label('Facility ID')->searchable(),
-            TextColumn::make('name')->searchable()->weight('bold'),
-            TextColumn::make('community_of_license')->label('Community')->searchable(),
-            TextColumn::make('state')->badge(),
+            TextColumn::make('facility_id')->label('Facility ID')->searchable()->sortable(),
+            TextColumn::make('name')->searchable()->weight('bold')->limit(35),
+            TextColumn::make('community_of_license')->label('Community')->searchable()->sortable(),
+            TextColumn::make('state')->badge()->sortable(),
+            TextColumn::make('owner')->label('Owner / Licensee')->searchable()->limit(30)->toggleable(),
             TextColumn::make('asr_number')->label('ASR #')->toggleable(),
-            TextColumn::make('licenses_count')->counts('licenses')->label('Licenses'),
-            TextColumn::make('contact_engineer')->label('Engineer')->toggleable(),
-        ])->defaultSort('name');
+            TextColumn::make('licenses_count')->counts('licenses')->label('# Licenses'),
+            TextColumn::make('antenna_haat_meters')->label('HAAT (m)')->numeric(2)->toggleable(),
+            TextColumn::make('antenna_amsl_meters')->label('AMSL (m)')->numeric(2)->toggleable(),
+            TextColumn::make('latitude')->numeric(6)->toggleable(isToggledHiddenByDefault: true),
+            TextColumn::make('longitude')->numeric(6)->toggleable(isToggledHiddenByDefault: true),
+            TextColumn::make('contact_engineer')->label('Engineer')->toggleable(isToggledHiddenByDefault: true),
+        ])->defaultSort('name')->striped()->paginated([25, 50, 100]);
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FccFacilityResource.php
+++ b/app/Filament/Resources/FccFacilityResource.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccFacilityResource\Pages\ManageFccFacilities;
+use App\Models\FccFacility;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FccFacilityResource extends Resource
+{
+    protected static ?string $model = FccFacility::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    protected static ?string $navigationLabel = 'Facilities';
+
+    protected static ?string $modelLabel = 'Facility';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 40;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('facility_id')->label('FCC Facility ID')->required()->unique(ignoreRecord: true),
+            TextInput::make('name')->required(),
+            TextInput::make('community_of_license')->label('Community of License'),
+            TextInput::make('state')->maxLength(2),
+            TextInput::make('latitude')->numeric(),
+            TextInput::make('longitude')->numeric(),
+            TextInput::make('antenna_haat_meters')->label('Antenna HAAT (m)')->numeric(),
+            TextInput::make('antenna_amsl_meters')->label('Antenna AMSL (m)')->numeric(),
+            TextInput::make('asr_number')->label('Antenna Structure Reg. #'),
+            TextInput::make('owner'),
+            TextInput::make('contact_engineer')->label('Contact Engineer'),
+            Textarea::make('notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('facility_id')->label('Facility ID')->searchable(),
+            TextColumn::make('name')->searchable()->weight('bold'),
+            TextColumn::make('community_of_license')->label('Community')->searchable(),
+            TextColumn::make('state')->badge(),
+            TextColumn::make('asr_number')->label('ASR #')->toggleable(),
+            TextColumn::make('licenses_count')->counts('licenses')->label('Licenses'),
+            TextColumn::make('contact_engineer')->label('Engineer')->toggleable(),
+        ])->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ManageFccFacilities::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccFacilityResource/Pages/ManageFccFacilities.php
+++ b/app/Filament/Resources/FccFacilityResource/Pages/ManageFccFacilities.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccFacilityResource\Pages;
+
+use App\Filament\Resources\FccFacilityResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccFacilities extends ManageRecords
+{
+    protected static string $resource = FccFacilityResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccFormFilingResource.php
+++ b/app/Filament/Resources/FccFormFilingResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccFormFilingResource\Pages\ManageFccFormFilings;
+use App\Models\FccFormFiling;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccFormFilingResource extends Resource
+{
+    protected static ?string $model = FccFormFiling::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $navigationLabel = 'Form Filings';
+
+    protected static ?string $modelLabel = 'FCC Form Filing';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 150;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->searchable(),
+            TextInput::make('form_number')->required()
+                ->placeholder('e.g. 323, 323-E, 397, 2100-H, 2100-A, 2100-B'),
+            TextInput::make('form_title')->required()->columnSpanFull()
+                ->placeholder('e.g. Biennial Ownership Report (Commercial)'),
+            DatePicker::make('filed_date')->required(),
+            TextInput::make('file_number')->label('FCC File Number')
+                ->placeholder('Assigned by FCC after filing'),
+            Select::make('status')->required()->options([
+                'filed' => 'Filed',
+                'pending_review' => 'Pending FCC Review',
+                'granted' => 'Granted',
+                'returned' => 'Returned for Correction',
+                'dismissed' => 'Dismissed',
+                'denied' => 'Denied',
+            ])->default('filed'),
+            TextInput::make('filed_by'),
+            Textarea::make('notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('filed_date')->date('M d, Y')->sortable(),
+            TextColumn::make('form_number')->badge()->color('warning'),
+            TextColumn::make('form_title')->limit(40)->searchable(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('file_number')->toggleable(),
+            TextColumn::make('status')->badge()->color(fn ($s) => match ($s) {
+                'granted' => 'success', 'filed' => 'info',
+                'pending_review' => 'warning', 'returned' => 'warning',
+                'dismissed', 'denied' => 'danger', default => 'gray',
+            })->formatStateUsing(fn ($s) => str($s)->headline()),
+        ])->filters([
+            SelectFilter::make('form_number')->options([
+                '323' => '323 (Ownership)', '323-E' => '323-E (NCE Ownership)',
+                '397' => '397 (EEO)', '2100-H' => "2100-H (Children's TV)",
+                '2100-A' => '2100-A (Renewal)',
+            ]),
+            SelectFilter::make('status')->options([
+                'filed' => 'Filed', 'pending_review' => 'Pending', 'granted' => 'Granted',
+            ]),
+        ])->defaultSort('filed_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccFormFilings::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccFormFilingResource.php
+++ b/app/Filament/Resources/FccFormFilingResource.php
@@ -77,6 +77,11 @@ class FccFormFilingResource extends Resource
         ])->defaultSort('filed_date', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccFormFilings::route('/')];

--- a/app/Filament/Resources/FccFormFilingResource/Pages/ManageFccFormFilings.php
+++ b/app/Filament/Resources/FccFormFilingResource/Pages/ManageFccFormFilings.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccFormFilingResource\Pages;
+
+use App\Filament\Resources\FccFormFilingResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccFormFilings extends ManageRecords
+{
+    protected static string $resource = FccFormFilingResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccIssuesProgramsListResource.php
+++ b/app/Filament/Resources/FccIssuesProgramsListResource.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccIssuesProgramsListResource\Pages\ManageFccIssuesProgramsLists;
+use App\Models\FccIssuesProgramsList;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccIssuesProgramsListResource extends Resource
+{
+    protected static ?string $model = FccIssuesProgramsList::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $navigationLabel = 'Issues/Programs';
+
+    protected static ?string $modelLabel = 'Issues/Programs List';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 110;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            TextInput::make('quarter_year')->numeric()->required()->default(now()->year),
+            Select::make('quarter')->required()->options([
+                'Q1' => 'Q1 (Jan-Mar)',
+                'Q2' => 'Q2 (Apr-Jun)',
+                'Q3' => 'Q3 (Jul-Sep)',
+                'Q4' => 'Q4 (Oct-Dec)',
+            ]),
+            DatePicker::make('placed_in_file_date')->label('Placed in Public File')
+                ->helperText('Required within 10 days of quarter end (§73.3526)'),
+            Select::make('status')->required()->options([
+                'draft' => 'Draft',
+                'placed_in_file' => 'Placed in Public File',
+                'late_filed' => 'Late-Filed',
+            ])->default('draft'),
+            Textarea::make('preparer_notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('quarter_year')->label('Year')->sortable(),
+            TextColumn::make('quarter')->badge(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold')->searchable(),
+            TextColumn::make('placed_in_file_date')->date('M d, Y')->label('Placed In File'),
+            TextColumn::make('entries_count')->counts('entries')->label('# Programs'),
+            TextColumn::make('status')->badge()->color(fn ($s) => match ($s) {
+                'placed_in_file' => 'success', 'draft' => 'warning',
+                'late_filed' => 'danger', default => 'gray',
+            })->formatStateUsing(fn ($s) => str($s)->headline()),
+        ])->filters([
+            SelectFilter::make('status')->options([
+                'draft' => 'Draft', 'placed_in_file' => 'Placed In File', 'late_filed' => 'Late',
+            ]),
+        ])->defaultSort('quarter_year', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccIssuesProgramsLists::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccIssuesProgramsListResource.php
+++ b/app/Filament/Resources/FccIssuesProgramsListResource.php
@@ -69,6 +69,11 @@ class FccIssuesProgramsListResource extends Resource
         ])->defaultSort('quarter_year', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccIssuesProgramsLists::route('/')];

--- a/app/Filament/Resources/FccIssuesProgramsListResource/Pages/ManageFccIssuesProgramsLists.php
+++ b/app/Filament/Resources/FccIssuesProgramsListResource/Pages/ManageFccIssuesProgramsLists.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccIssuesProgramsListResource\Pages;
+
+use App\Filament\Resources\FccIssuesProgramsListResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccIssuesProgramsLists extends ManageRecords
+{
+    protected static string $resource = FccIssuesProgramsListResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccLicenseResource.php
+++ b/app/Filament/Resources/FccLicenseResource.php
@@ -179,6 +179,11 @@ class FccLicenseResource extends Resource
                     'at_risk' => 'At Risk',
                     'non_compliant' => 'Non-Compliant',
                 ]),
+                SelectFilter::make('state')
+                    ->relationship('facility', 'state')
+                    ->label('State')
+                    ->searchable()
+                    ->preload(),
             ])
             ->recordActions([
                 ViewAction::make(),
@@ -189,7 +194,11 @@ class FccLicenseResource extends Resource
                     DeleteBulkAction::make(),
                 ]),
             ])
-            ->defaultSort('call_sign');
+            ->defaultSort('call_sign')
+            ->striped()
+            ->paginated([25, 50, 100, 250])
+            ->persistFiltersInSession()
+            ->persistSortInSession();
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FccLicenseResource.php
+++ b/app/Filament/Resources/FccLicenseResource.php
@@ -213,13 +213,20 @@ class FccLicenseResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return (string) FccLicense::query()->count();
+        // Cached for 5 minutes — without this every page load pays for
+        // a full COUNT on ~60K licenses.
+        return cache()->remember('fcc.licenses.count', 300, function () {
+            return (string) FccLicense::query()->count();
+        });
     }
 
     public static function getNavigationBadgeColor(): ?string
     {
-        $atRisk = FccLicense::query()->whereIn('status', ['at_risk', 'non_compliant'])->count();
-
-        return $atRisk > 0 ? 'danger' : 'success';
+        return cache()->remember('fcc.licenses.atrisk_color', 300, function () {
+            $atRisk = FccLicense::query()
+                ->whereIn('status', ['at_risk', 'non_compliant'])
+                ->count();
+            return $atRisk > 0 ? 'danger' : 'success';
+        });
     }
 }

--- a/app/Filament/Resources/FccLicenseResource.php
+++ b/app/Filament/Resources/FccLicenseResource.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccLicenseResource\Pages\CreateFccLicense;
+use App\Filament\Resources\FccLicenseResource\Pages\EditFccLicense;
+use App\Filament\Resources\FccLicenseResource\Pages\ListFccLicenses;
+use App\Filament\Resources\FccLicenseResource\Pages\ViewFccLicense;
+use App\Models\FccFacility;
+use App\Models\FccLicense;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccLicenseResource extends Resource
+{
+    protected static ?string $model = FccLicense::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-identification';
+
+    protected static ?string $navigationLabel = 'Licenses';
+
+    protected static ?string $modelLabel = 'FCC License';
+
+    protected static ?string $pluralModelLabel = 'FCC Licenses';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 10;
+
+    protected static ?string $recordTitleAttribute = 'call_sign';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make('License Identification')
+                ->columnSpanFull()
+                ->schema([
+                    TextInput::make('call_sign')
+                        ->label('Call Sign')
+                        ->required()
+                        ->placeholder('e.g., KXYZ-FM, WABC-AM')
+                        ->unique(ignoreRecord: true)
+                        ->maxLength(20),
+                    TextInput::make('frn')
+                        ->label('FCC Registration Number (FRN)')
+                        ->required()
+                        ->placeholder('10-digit FRN')
+                        ->maxLength(20),
+                    TextInput::make('licensee')
+                        ->label('Licensee (Legal Entity)')
+                        ->required()
+                        ->placeholder('e.g., Market Hall Broadcasting, LLC')
+                        ->maxLength(255),
+                    Select::make('service')
+                        ->label('Service')
+                        ->required()
+                        ->options([
+                            'AM' => 'AM (Standard Broadcast)',
+                            'FM' => 'FM (Commercial)',
+                            'TV' => 'Full-Power Television',
+                            'LPFM' => 'Low Power FM',
+                            'LPTV' => 'Low Power Television',
+                            'FX' => 'FM Translator',
+                            'TX' => 'TV Translator',
+                            'DT' => 'Digital TV',
+                            'DC' => 'Digital Class A',
+                            'DD' => 'Digital LPTV',
+                            'CA' => 'Class A TV',
+                            'OTHER' => 'Other',
+                        ])
+                        ->default('FM'),
+                    TextInput::make('channel_or_frequency')
+                        ->label('Channel / Frequency')
+                        ->placeholder('e.g., 98.7 MHz or Ch. 27'),
+                ])->columns(2),
+
+            Section::make('Authorization Dates')
+                ->columnSpanFull()
+                ->schema([
+                    DatePicker::make('grant_date')->label('License Grant Date'),
+                    DatePicker::make('last_renewal_date')->label('Last Renewal'),
+                    DatePicker::make('expiration_date')->label('Expiration Date')->required(),
+                ])->columns(3),
+
+            Section::make('Compliance Status')
+                ->columnSpanFull()
+                ->schema([
+                    Select::make('status')
+                        ->required()
+                        ->options([
+                            'active' => 'Active',
+                            'expiring_soon' => 'Expiring Soon',
+                            'at_risk' => 'At Risk',
+                            'non_compliant' => 'Non-Compliant',
+                            'silent' => 'Silent (47 CFR 73.1740)',
+                            'cancelled' => 'Cancelled',
+                        ])->default('active'),
+                    TextInput::make('compliance_score')
+                        ->label('Compliance Score (%)')
+                        ->numeric()
+                        ->minValue(0)
+                        ->maxValue(100)
+                        ->step(0.1)
+                        ->default(100),
+                    Select::make('facility_id')
+                        ->label('Facility')
+                        ->relationship('facility', 'name')
+                        ->searchable()
+                        ->preload(),
+                ])->columns(3),
+
+            Section::make('Notes')
+                ->columnSpanFull()
+                ->schema([
+                    Textarea::make('public_notes')
+                        ->rows(4)
+                        ->placeholder('Public-facing notes about this authorization'),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('call_sign')
+                    ->label('Call Sign')
+                    ->weight('bold')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('licensee')
+                    ->searchable()
+                    ->limit(35)
+                    ->sortable(),
+                TextColumn::make('service')
+                    ->badge()
+                    ->color('warning'),
+                TextColumn::make('channel_or_frequency')->label('Freq/Ch'),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn ($state) => match ($state) {
+                        'active' => 'success',
+                        'expiring_soon', 'at_risk' => 'warning',
+                        'non_compliant' => 'danger',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn ($state) => str($state)->headline()),
+                TextColumn::make('expiration_date')
+                    ->label('Expiration')
+                    ->date('M d, Y')
+                    ->sortable(),
+                TextColumn::make('compliance_score')
+                    ->label('Compliance')
+                    ->suffix('%')
+                    ->sortable()
+                    ->color(fn ($state) => $state >= 95 ? 'success' : ($state >= 80 ? 'warning' : 'danger')),
+                TextColumn::make('frn')->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('service')->options([
+                    'AM' => 'AM', 'FM' => 'FM', 'TV' => 'TV', 'LPFM' => 'LPFM',
+                    'LPTV' => 'LPTV', 'FX' => 'FM Translator',
+                ]),
+                SelectFilter::make('status')->options([
+                    'active' => 'Active',
+                    'expiring_soon' => 'Expiring Soon',
+                    'at_risk' => 'At Risk',
+                    'non_compliant' => 'Non-Compliant',
+                ]),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('call_sign');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListFccLicenses::route('/'),
+            'create' => CreateFccLicense::route('/create'),
+            'view' => ViewFccLicense::route('/{record}'),
+            'edit' => EditFccLicense::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) FccLicense::query()->count();
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        $atRisk = FccLicense::query()->whereIn('status', ['at_risk', 'non_compliant'])->count();
+
+        return $atRisk > 0 ? 'danger' : 'success';
+    }
+}

--- a/app/Filament/Resources/FccLicenseResource.php
+++ b/app/Filament/Resources/FccLicenseResource.php
@@ -55,12 +55,10 @@ class FccLicenseResource extends Resource
                         ->maxLength(20),
                     TextInput::make('frn')
                         ->label('FCC Registration Number (FRN)')
-                        ->required()
-                        ->placeholder('10-digit FRN')
+                        ->placeholder('10-digit FRN — populated by `fcc:import-lms`')
                         ->maxLength(20),
                     TextInput::make('licensee')
                         ->label('Licensee (Legal Entity)')
-                        ->required()
                         ->placeholder('e.g., Market Hall Broadcasting, LLC')
                         ->maxLength(255),
                     Select::make('service')
@@ -91,7 +89,7 @@ class FccLicenseResource extends Resource
                 ->schema([
                     DatePicker::make('grant_date')->label('License Grant Date'),
                     DatePicker::make('last_renewal_date')->label('Last Renewal'),
-                    DatePicker::make('expiration_date')->label('Expiration Date')->required(),
+                    DatePicker::make('expiration_date')->label('Expiration Date'),
                 ])->columns(3),
 
             Section::make('Compliance Status')
@@ -118,7 +116,7 @@ class FccLicenseResource extends Resource
                         ->label('Facility')
                         ->relationship('facility', 'name')
                         ->searchable()
-                        ->preload(),
+                        ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->facility_id} — {$record->name}"),
                 ])->columns(3),
 
             Section::make('Notes')
@@ -199,6 +197,11 @@ class FccLicenseResource extends Resource
             ->paginated([25, 50, 100, 250])
             ->persistFiltersInSession()
             ->persistSortInSession();
+    }
+
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('facility');
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FccLicenseResource.php
+++ b/app/Filament/Resources/FccLicenseResource.php
@@ -178,10 +178,20 @@ class FccLicenseResource extends Resource
                     'non_compliant' => 'Non-Compliant',
                 ]),
                 SelectFilter::make('state')
-                    ->relationship('facility', 'state')
                     ->label('State')
-                    ->searchable()
-                    ->preload(),
+                    ->options(fn () => \App\Models\FccFacility::query()
+                        ->whereNotNull('state')
+                        ->where('state', '!=', '')
+                        ->distinct()
+                        ->orderBy('state')
+                        ->pluck('state', 'state')
+                        ->toArray())
+                    ->query(function ($query, array $data) {
+                        if (! empty($data['value'])) {
+                            $query->whereHas('facility', fn ($q) => $q->where('state', $data['value']));
+                        }
+                    })
+                    ->searchable(),
             ])
             ->recordActions([
                 ViewAction::make(),

--- a/app/Filament/Resources/FccLicenseResource/Pages/CreateFccLicense.php
+++ b/app/Filament/Resources/FccLicenseResource/Pages/CreateFccLicense.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\FccLicenseResource\Pages;
+
+use App\Filament\Resources\FccLicenseResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateFccLicense extends CreateRecord
+{
+    protected static string $resource = FccLicenseResource::class;
+}

--- a/app/Filament/Resources/FccLicenseResource/Pages/EditFccLicense.php
+++ b/app/Filament/Resources/FccLicenseResource/Pages/EditFccLicense.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\FccLicenseResource\Pages;
+
+use App\Filament\Resources\FccLicenseResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditFccLicense extends EditRecord
+{
+    protected static string $resource = FccLicenseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ViewAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccLicenseResource/Pages/ListFccLicenses.php
+++ b/app/Filament/Resources/FccLicenseResource/Pages/ListFccLicenses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccLicenseResource\Pages;
+
+use App\Filament\Resources\FccLicenseResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListFccLicenses extends ListRecords
+{
+    protected static string $resource = FccLicenseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccLicenseResource/Pages/ViewFccLicense.php
+++ b/app/Filament/Resources/FccLicenseResource/Pages/ViewFccLicense.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccLicenseResource\Pages;
+
+use App\Filament\Resources\FccLicenseResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewFccLicense extends ViewRecord
+{
+    protected static string $resource = FccLicenseResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccPoliticalFileEntryResource.php
+++ b/app/Filament/Resources/FccPoliticalFileEntryResource.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccPoliticalFileEntryResource\Pages\ManageFccPoliticalFileEntries;
+use App\Models\FccPoliticalFileEntry;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FccPoliticalFileEntryResource extends Resource
+{
+    protected static ?string $model = FccPoliticalFileEntry::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-megaphone';
+
+    protected static ?string $navigationLabel = 'Political File';
+
+    protected static ?string $modelLabel = 'Political File Entry';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 120;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            DatePicker::make('order_date')->required(),
+            TextInput::make('candidate_or_issue')->required()
+                ->placeholder('e.g. Jane Doe (D-CA), Prop 12'),
+            TextInput::make('sponsor')->required()
+                ->placeholder('Buying entity / committee / PAC'),
+            Select::make('office')->options([
+                'federal_president' => 'Federal — President',
+                'federal_senate' => 'Federal — U.S. Senate',
+                'federal_house' => 'Federal — U.S. House',
+                'state_governor' => 'State — Governor',
+                'state_legislature' => 'State — Legislature',
+                'state_other' => 'State — Other',
+                'local' => 'Local',
+                'ballot_initiative' => 'Ballot Initiative',
+                'issue_ad' => 'Issue Advertising',
+            ]),
+            DatePicker::make('flight_start_date')->label('Flight Start'),
+            DatePicker::make('flight_end_date')->label('Flight End'),
+            TextInput::make('spots_purchased')->numeric(),
+            TextInput::make('rate_per_spot')->numeric()->prefix('$'),
+            TextInput::make('total_amount')->numeric()->prefix('$'),
+            Toggle::make('lowest_unit_rate_window')->label('LUR Window Active')
+                ->helperText('45 days before primary / 60 days before general'),
+            DatePicker::make('uploaded_to_public_file_date')->label('Uploaded to Public File')
+                ->helperText('Required ASAP per §73.1943'),
+            TextInput::make('contract_pdf_path')->label('Contract PDF Path'),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('order_date')->date('M d, Y')->sortable(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('candidate_or_issue')->searchable()->limit(28),
+            TextColumn::make('sponsor')->searchable()->limit(24)->toggleable(),
+            TextColumn::make('office')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('spots_purchased')->numeric(),
+            TextColumn::make('total_amount')->money('USD'),
+            IconColumn::make('lowest_unit_rate_window')->boolean()->label('LUR'),
+            TextColumn::make('uploaded_to_public_file_date')->date('M d, Y')->label('In Public File')
+                ->color(fn ($state) => $state ? 'success' : 'danger'),
+        ])->defaultSort('order_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccPoliticalFileEntries::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccPoliticalFileEntryResource.php
+++ b/app/Filament/Resources/FccPoliticalFileEntryResource.php
@@ -77,6 +77,11 @@ class FccPoliticalFileEntryResource extends Resource
         ])->defaultSort('order_date', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccPoliticalFileEntries::route('/')];

--- a/app/Filament/Resources/FccPoliticalFileEntryResource/Pages/ManageFccPoliticalFileEntries.php
+++ b/app/Filament/Resources/FccPoliticalFileEntryResource/Pages/ManageFccPoliticalFileEntries.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccPoliticalFileEntryResource\Pages;
+
+use App\Filament\Resources\FccPoliticalFileEntryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccPoliticalFileEntries extends ManageRecords
+{
+    protected static string $resource = FccPoliticalFileEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccPublicFileDocumentResource.php
+++ b/app/Filament/Resources/FccPublicFileDocumentResource.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccPublicFileDocumentResource\Pages\ManageFccPublicFileDocuments;
+use App\Models\FccPublicFileDocument;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccPublicFileDocumentResource extends Resource
+{
+    protected static ?string $model = FccPublicFileDocument::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-folder-open';
+
+    protected static ?string $navigationLabel = 'Public File';
+
+    protected static ?string $modelLabel = 'Public File Document';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 80;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            Select::make('document_type')->required()->options([
+                'authorization' => 'License Authorization',
+                'application' => 'Application',
+                'contour_map' => 'Contour Map',
+                'ownership_report' => 'Ownership Report (Form 323)',
+                'biennial_ownership_report' => 'Biennial Ownership Report',
+                'eeo_public_file' => 'EEO Public File Report',
+                'political_file' => 'Political File',
+                'issues_programs_list' => 'Issues/Programs List',
+                'children_tv_report' => "Children's TV Report (Form 2100-H)",
+                'shared_service_agreement' => 'Shared Service Agreement',
+                'time_brokerage_agreement' => 'Time Brokerage Agreement',
+                'joint_sales_agreement' => 'Joint Sales Agreement',
+                'donor_list' => 'Donor List (NCE)',
+                'station_id_announcement' => 'Station ID Announcement',
+                'public_notice' => 'Public Notice',
+                'letter_to_public' => 'Letter / Email to Public',
+                'other' => 'Other',
+            ])->helperText('Per 47 CFR §73.3526'),
+            TextInput::make('title')->required()->columnSpanFull(),
+            DatePicker::make('document_date')->label('Document Date'),
+            DatePicker::make('uploaded_to_lms_date')->label('Uploaded to FCC LMS'),
+            DatePicker::make('retention_until')->label('Retain Until')
+                ->helperText('Typically license term'),
+            TextInput::make('lms_url')->url()->columnSpanFull()
+                ->placeholder('https://publicfiles.fcc.gov/...'),
+            TextInput::make('uploaded_by'),
+            Textarea::make('notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('uploaded_to_lms_date')->date('M d, Y')->label('Uploaded')->sortable(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('document_type')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('title')->searchable()->limit(40),
+            TextColumn::make('document_date')->date('M d, Y')->label('Doc Date'),
+            TextColumn::make('uploaded_by')->toggleable(),
+            TextColumn::make('retention_until')->date('M d, Y')->label('Retain Until')->toggleable(),
+        ])->filters([
+            SelectFilter::make('document_type')->options([
+                'political_file' => 'Political File',
+                'issues_programs_list' => 'Issues/Programs List',
+                'eeo_public_file' => 'EEO Public File',
+                'children_tv_report' => "Children's TV Report",
+                'biennial_ownership_report' => 'Biennial Ownership',
+                'authorization' => 'License Authorization',
+            ]),
+        ])->defaultSort('uploaded_to_lms_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccPublicFileDocuments::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccPublicFileDocumentResource.php
+++ b/app/Filament/Resources/FccPublicFileDocumentResource.php
@@ -85,6 +85,11 @@ class FccPublicFileDocumentResource extends Resource
         ])->defaultSort('uploaded_to_lms_date', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccPublicFileDocuments::route('/')];

--- a/app/Filament/Resources/FccPublicFileDocumentResource/Pages/ManageFccPublicFileDocuments.php
+++ b/app/Filament/Resources/FccPublicFileDocumentResource/Pages/ManageFccPublicFileDocuments.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccPublicFileDocumentResource\Pages;
+
+use App\Filament\Resources\FccPublicFileDocumentResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccPublicFileDocuments extends ManageRecords
+{
+    protected static string $resource = FccPublicFileDocumentResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccRegulatoryFeeResource.php
+++ b/app/Filament/Resources/FccRegulatoryFeeResource.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccRegulatoryFeeResource\Pages\ManageFccRegulatoryFees;
+use App\Models\FccRegulatoryFee;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccRegulatoryFeeResource extends Resource
+{
+    protected static ?string $model = FccRegulatoryFee::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-banknotes';
+
+    protected static ?string $navigationLabel = 'Regulatory Fees';
+
+    protected static ?string $modelLabel = 'Regulatory Fee';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 140;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            TextInput::make('fiscal_year')->numeric()->required()->default(now()->year),
+            TextInput::make('fee_category')->required()
+                ->placeholder('e.g. AM Class B, FM Class C, TV Markets 1-10')
+                ->helperText('Per FCC annual Reg Fee schedule'),
+            TextInput::make('amount_due')->numeric()->prefix('$')->required(),
+            TextInput::make('amount_paid')->numeric()->prefix('$')->default(0),
+            DatePicker::make('due_date')->required(),
+            DatePicker::make('paid_date'),
+            TextInput::make('confirmation_number')->label('Pay.gov Confirmation #'),
+            Select::make('status')->required()->options([
+                'pending' => 'Pending',
+                'paid' => 'Paid',
+                'overdue' => 'Overdue',
+                'waiver_requested' => 'Waiver Requested',
+            ])->default('pending'),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('fiscal_year')->label('FY')->sortable(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('fee_category')->limit(35),
+            TextColumn::make('amount_due')->money('USD'),
+            TextColumn::make('amount_paid')->money('USD'),
+            TextColumn::make('due_date')->date('M d, Y')->sortable(),
+            TextColumn::make('status')->badge()->color(fn ($s) => match ($s) {
+                'paid' => 'success', 'pending' => 'warning',
+                'overdue' => 'danger', 'waiver_requested' => 'info', default => 'gray',
+            })->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('confirmation_number')->toggleable(),
+        ])->filters([
+            SelectFilter::make('status')->options([
+                'pending' => 'Pending', 'paid' => 'Paid',
+                'overdue' => 'Overdue', 'waiver_requested' => 'Waiver',
+            ]),
+        ])->defaultSort('due_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccRegulatoryFees::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccRegulatoryFeeResource.php
+++ b/app/Filament/Resources/FccRegulatoryFeeResource.php
@@ -71,6 +71,11 @@ class FccRegulatoryFeeResource extends Resource
         ])->defaultSort('due_date', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccRegulatoryFees::route('/')];

--- a/app/Filament/Resources/FccRegulatoryFeeResource/Pages/ManageFccRegulatoryFees.php
+++ b/app/Filament/Resources/FccRegulatoryFeeResource/Pages/ManageFccRegulatoryFees.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccRegulatoryFeeResource\Pages;
+
+use App\Filament\Resources\FccRegulatoryFeeResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccRegulatoryFees extends ManageRecords
+{
+    protected static string $resource = FccRegulatoryFeeResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccRuleResource.php
+++ b/app/Filament/Resources/FccRuleResource.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccRuleResource\Pages\ManageFccRules;
+use App\Models\FccRule;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccRuleResource extends Resource
+{
+    protected static ?string $model = FccRule::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-scale';
+
+    protected static ?string $navigationLabel = 'FCC Rules';
+
+    protected static ?string $modelLabel = 'FCC Rule';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 50;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            TextInput::make('rule_number')->required()->placeholder('e.g. 73.3526')
+                ->helperText('CFR section number'),
+            TextInput::make('part')->placeholder('e.g. Part 73'),
+            TextInput::make('title')->required()->columnSpanFull(),
+            Textarea::make('description')->columnSpanFull()->rows(4),
+            Select::make('category')->required()->options([
+                'technical_standards' => 'Technical Standards',
+                'operational_rules' => 'Operational Rules',
+                'eas_requirements' => 'EAS Requirements',
+                'public_file_rules' => 'Public File Rules',
+                'ownership_control' => 'Ownership / Control',
+                'reporting_requirements' => 'Reporting Requirements',
+            ]),
+            Select::make('severity')->required()->options([
+                'low' => 'Low', 'medium' => 'Medium',
+                'high' => 'High', 'critical' => 'Critical',
+            ]),
+            Toggle::make('quarterly_filing_required')->label('Requires Quarterly Filing'),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('rule_number')->label('CFR Section')->weight('bold')->searchable()->sortable(),
+            TextColumn::make('part')->badge(),
+            TextColumn::make('title')->searchable()->limit(50),
+            TextColumn::make('category')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('severity')->badge()->color(fn ($s) => match ($s) {
+                'critical' => 'danger', 'high' => 'warning',
+                'medium' => 'info', 'low' => 'gray', default => 'gray',
+            }),
+            IconColumn::make('quarterly_filing_required')->label('Qtrly')->boolean(),
+        ])->filters([
+            SelectFilter::make('category')->options([
+                'technical_standards' => 'Technical Standards',
+                'operational_rules' => 'Operational Rules',
+                'eas_requirements' => 'EAS Requirements',
+                'public_file_rules' => 'Public File Rules',
+                'ownership_control' => 'Ownership / Control',
+                'reporting_requirements' => 'Reporting Requirements',
+            ]),
+            SelectFilter::make('severity')->options([
+                'low' => 'Low', 'medium' => 'Medium', 'high' => 'High', 'critical' => 'Critical',
+            ]),
+        ])->defaultSort('rule_number');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ManageFccRules::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccRuleResource/Pages/ManageFccRules.php
+++ b/app/Filament/Resources/FccRuleResource/Pages/ManageFccRules.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccRuleResource\Pages;
+
+use App\Filament\Resources\FccRuleResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccRules extends ManageRecords
+{
+    protected static string $resource = FccRuleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccStationLogEntryResource.php
+++ b/app/Filament/Resources/FccStationLogEntryResource.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccStationLogEntryResource\Pages\ManageFccStationLogEntries;
+use App\Models\FccStationLogEntry;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class FccStationLogEntryResource extends Resource
+{
+    protected static ?string $model = FccStationLogEntry::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-pencil-square';
+
+    protected static ?string $navigationLabel = 'Station Log';
+
+    protected static ?string $modelLabel = 'Station Log Entry';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 130;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            DateTimePicker::make('logged_at')->required()->seconds(false)->default(now()),
+            Select::make('entry_type')->required()->options([
+                'transmitter_reading' => 'Transmitter Reading',
+                'eas_test' => 'EAS Test',
+                'tower_lighting_check' => 'Tower Lighting Check',
+                'directional_pattern_check' => 'Directional Pattern Check (AM)',
+                'sign_on' => 'Sign-On',
+                'sign_off' => 'Sign-Off',
+                'station_id' => 'Station ID',
+                'maintenance' => 'Maintenance',
+                'power_change' => 'Power Change',
+                'incident' => 'Incident',
+                'other' => 'Other',
+            ])->helperText('Per 47 CFR §73.1820'),
+            Textarea::make('summary')->required()->columnSpanFull(),
+            KeyValue::make('readings')->columnSpanFull()->keyLabel('Reading')->valueLabel('Value')
+                ->helperText('e.g. power_kw, swr, plate_voltage, plate_current'),
+            TextInput::make('logged_by'),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('logged_at')->dateTime('M d H:i')->label('Logged At')->sortable(),
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold'),
+            TextColumn::make('entry_type')->badge()->formatStateUsing(fn ($s) => str($s)->headline()),
+            TextColumn::make('summary')->limit(40)->wrap(),
+            TextColumn::make('logged_by')->toggleable(),
+        ])->filters([
+            SelectFilter::make('entry_type')->options([
+                'transmitter_reading' => 'Transmitter',
+                'eas_test' => 'EAS', 'tower_lighting_check' => 'Tower Lighting',
+                'directional_pattern_check' => 'AM Pattern',
+            ]),
+            SelectFilter::make('license_id')->relationship('license', 'call_sign')->label('Call Sign'),
+        ])->defaultSort('logged_at', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccStationLogEntries::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccStationLogEntryResource.php
+++ b/app/Filament/Resources/FccStationLogEntryResource.php
@@ -72,6 +72,11 @@ class FccStationLogEntryResource extends Resource
         ])->defaultSort('logged_at', 'desc');
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return ['index' => ManageFccStationLogEntries::route('/')];

--- a/app/Filament/Resources/FccStationLogEntryResource/Pages/ManageFccStationLogEntries.php
+++ b/app/Filament/Resources/FccStationLogEntryResource/Pages/ManageFccStationLogEntries.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccStationLogEntryResource\Pages;
+
+use App\Filament\Resources\FccStationLogEntryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccStationLogEntries extends ManageRecords
+{
+    protected static string $resource = FccStationLogEntryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccTowerLightingInspectionResource.php
+++ b/app/Filament/Resources/FccTowerLightingInspectionResource.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccTowerLightingInspectionResource\Pages\ManageFccTowerLightingInspections;
+use App\Models\FccTowerLightingInspection;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FccTowerLightingInspectionResource extends Resource
+{
+    protected static ?string $model = FccTowerLightingInspection::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-light-bulb';
+
+    protected static ?string $navigationLabel = 'Tower Inspections';
+
+    protected static ?string $modelLabel = 'Tower Lighting Inspection';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 100;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('asr_registration_id')->relationship('asr', 'asr_number')->searchable()->label('ASR'),
+            Select::make('facility_id')->relationship('facility', 'name')->searchable()->label('Facility'),
+            DatePicker::make('inspection_date')->required(),
+            TextInput::make('inspector_name'),
+            Select::make('result')->required()->options([
+                'operational' => 'Fully Operational',
+                'minor_issue' => 'Minor Issue Found',
+                'failed' => 'Failed Inspection',
+            ])->default('operational'),
+            DatePicker::make('next_inspection_due')->required()
+                ->helperText('§17.47 — at intervals not exceeding 3 months'),
+            Toggle::make('automatic_monitor_observed')->label('Automatic Monitor Observed (24h)')->default(true),
+            Toggle::make('manual_observation_performed')->label('Manual Observation Performed')->default(true),
+            Textarea::make('findings')->columnSpanFull(),
+            Textarea::make('corrective_action')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('inspection_date')->date('M d, Y')->sortable(),
+            TextColumn::make('asr.asr_number')->label('ASR #')->weight('bold'),
+            TextColumn::make('facility.name')->label('Facility'),
+            TextColumn::make('inspector_name')->label('Inspector'),
+            TextColumn::make('result')->badge()->color(fn ($s) => match ($s) {
+                'operational' => 'success', 'minor_issue' => 'warning',
+                'failed' => 'danger', default => 'gray',
+            }),
+            IconColumn::make('automatic_monitor_observed')->boolean()->label('Auto Monitor'),
+            TextColumn::make('next_inspection_due')->date('M d, Y')->label('Next Due')
+                ->color(fn ($state) => $state && $state < now()->addDays(14) ? 'warning' : 'success'),
+        ])->defaultSort('inspection_date', 'desc');
+    }
+
+    public static function getPages(): array
+    {
+        return ['index' => ManageFccTowerLightingInspections::route('/')];
+    }
+}

--- a/app/Filament/Resources/FccTowerLightingInspectionResource/Pages/ManageFccTowerLightingInspections.php
+++ b/app/Filament/Resources/FccTowerLightingInspectionResource/Pages/ManageFccTowerLightingInspections.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Filament\Resources\FccTowerLightingInspectionResource\Pages;
+
+use App\Filament\Resources\FccTowerLightingInspectionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccTowerLightingInspections extends ManageRecords
+{
+    protected static string $resource = FccTowerLightingInspectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [CreateAction::make()];
+    }
+}

--- a/app/Filament/Resources/FccTransmitterResource.php
+++ b/app/Filament/Resources/FccTransmitterResource.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\FccTransmitterResource\Pages\ManageFccTransmitters;
+use App\Models\FccTransmitter;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class FccTransmitterResource extends Resource
+{
+    protected static ?string $model = FccTransmitter::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-signal';
+
+    protected static ?string $navigationLabel = 'Transmitters';
+
+    protected static ?string $modelLabel = 'Transmitter';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'FCC Compliance';
+
+    protected static ?int $navigationSort = 30;
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema->components([
+            Select::make('license_id')->relationship('license', 'call_sign')->required()->searchable(),
+            TextInput::make('manufacturer'),
+            TextInput::make('model'),
+            TextInput::make('serial_number'),
+            TextInput::make('rated_power_kw')->label('Rated Power (kW)')->numeric(),
+            TextInput::make('authorized_erp_kw')->label('Authorized ERP (kW)')->numeric()
+                ->helperText('47 CFR 73.211 — Effective Radiated Power'),
+            TextInput::make('measured_power_kw')->label('Measured Power (kW)')->numeric(),
+            DatePicker::make('last_proof_of_performance')->label('Last Proof of Performance'),
+            DatePicker::make('next_proof_due')->label('Next Proof Due'),
+            Toggle::make('eas_endec_present')->label('EAS ENDEC Installed (Part 11)'),
+            TextInput::make('eas_endec_model')->label('ENDEC Model'),
+            Select::make('status')->options([
+                'operating' => 'Operating',
+                'standby' => 'Standby',
+                'offline' => 'Offline',
+                'maintenance' => 'In Maintenance',
+            ])->default('operating'),
+            Textarea::make('notes')->columnSpanFull(),
+        ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table->columns([
+            TextColumn::make('license.call_sign')->label('Call Sign')->weight('bold')->searchable(),
+            TextColumn::make('manufacturer'),
+            TextColumn::make('model'),
+            TextColumn::make('authorized_erp_kw')->label('Auth ERP (kW)'),
+            TextColumn::make('measured_power_kw')->label('Measured (kW)')
+                ->color(fn ($state, $record) => $record->authorized_erp_kw && abs($state - $record->authorized_erp_kw) / $record->authorized_erp_kw > 0.05 ? 'danger' : 'success'),
+            IconColumn::make('eas_endec_present')->label('EAS')->boolean(),
+            TextColumn::make('next_proof_due')->date('M d, Y')->label('Next Proof'),
+            TextColumn::make('status')->badge()->color(fn ($state) => match ($state) {
+                'operating' => 'success', 'standby' => 'info',
+                'maintenance' => 'warning', 'offline' => 'danger', default => 'gray',
+            }),
+        ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ManageFccTransmitters::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/FccTransmitterResource.php
+++ b/app/Filament/Resources/FccTransmitterResource.php
@@ -72,6 +72,11 @@ class FccTransmitterResource extends Resource
         ]);
     }
 
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return parent::getEloquentQuery()->with('license');
+    }
+
     public static function getPages(): array
     {
         return [

--- a/app/Filament/Resources/FccTransmitterResource/Pages/ManageFccTransmitters.php
+++ b/app/Filament/Resources/FccTransmitterResource/Pages/ManageFccTransmitters.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\FccTransmitterResource\Pages;
+
+use App\Filament\Resources\FccTransmitterResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManageFccTransmitters extends ManageRecords
+{
+    protected static string $resource = FccTransmitterResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Widgets/FccComplianceActivityWidget.php
+++ b/app/Filament/Widgets/FccComplianceActivityWidget.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccComplianceEvent;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class FccComplianceActivityWidget extends BaseWidget
+{
+    protected static bool $isLazy = false;
+
+    protected int|string|array $columnSpan = 1;
+
+    protected static ?string $heading = 'Compliance Activity';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                FccComplianceEvent::query()
+                    ->orderByDesc('occurred_at')
+                    ->limit(10)
+            )
+            ->columns([
+                TextColumn::make('event_type')->icon(fn ($state) => match ($state) {
+                    'technical_review_passed' => 'heroicon-o-check-circle',
+                    'eas_test_filed' => 'heroicon-o-shield-check',
+                    'public_file_uploaded' => 'heroicon-o-document-arrow-up',
+                    'report_generated' => 'heroicon-o-document-text',
+                    'power_warning' => 'heroicon-o-exclamation-triangle',
+                    default => 'heroicon-o-information-circle',
+                })->iconColor(fn ($state) => match ($state) {
+                    'technical_review_passed', 'eas_test_filed' => 'success',
+                    'power_warning' => 'warning',
+                    default => 'info',
+                })->label(''),
+                TextColumn::make('summary')->wrap(),
+                TextColumn::make('actor')->label('Actor')->color('gray'),
+                TextColumn::make('occurred_at')->label('When')
+                    ->state(fn (FccComplianceEvent $r) => $r->occurred_at?->diffForHumans()),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Filament/Widgets/FccComplianceOverviewWidget.php
+++ b/app/Filament/Widgets/FccComplianceOverviewWidget.php
@@ -11,7 +11,10 @@ class FccComplianceOverviewWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
 
-    protected static ?string $heading = 'Compliance at a Glance';
+    public function getHeading(): ?string
+    {
+        return 'Compliance at a Glance';
+    }
 
     protected function getStats(): array
     {

--- a/app/Filament/Widgets/FccComplianceOverviewWidget.php
+++ b/app/Filament/Widgets/FccComplianceOverviewWidget.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccLicense;
+use App\Models\FccLicenseRuleStatus;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class FccComplianceOverviewWidget extends BaseWidget
+{
+    protected static bool $isLazy = false;
+
+    protected ?string $heading = 'Compliance at a Glance';
+
+    protected ?string $description = 'Real-time FCC compliance status across all licensed operations';
+
+    protected function getStats(): array
+    {
+        $licenseCount = FccLicense::query()->count();
+        $ruleStatuses = FccLicenseRuleStatus::query()
+            ->selectRaw('status, COUNT(*) as c')
+            ->groupBy('status')
+            ->pluck('c', 'status')
+            ->toArray();
+
+        $compliant   = (int) ($ruleStatuses['compliant'] ?? 0);
+        $atRisk      = (int) ($ruleStatuses['at_risk'] ?? 0);
+        $nonCompliant = (int) ($ruleStatuses['non_compliant'] ?? 0);
+        $total = max(1, $compliant + $atRisk + $nonCompliant);
+        $overall = round(($compliant / $total) * 100, 1);
+
+        $rulesTotal = $compliant + $atRisk + $nonCompliant;
+
+        return [
+            Stat::make('Overall Compliance', $overall.'%')
+                ->description('Compliant')
+                ->color($overall >= 95 ? 'success' : ($overall >= 85 ? 'warning' : 'danger'))
+                ->icon('heroicon-o-shield-check'),
+
+            Stat::make('Licenses', (string) $licenseCount)
+                ->description('Active authorizations')
+                ->color('warning')
+                ->icon('heroicon-o-identification'),
+
+            Stat::make('Rule Requirements', number_format($rulesTotal))
+                ->description('Total tracked')
+                ->color('info')
+                ->icon('heroicon-o-scale'),
+
+            Stat::make('Compliant', number_format($compliant))
+                ->description(sprintf('%.1f%%', ($compliant / $total) * 100))
+                ->color('success')
+                ->icon('heroicon-o-check-circle'),
+
+            Stat::make('At Risk', number_format($atRisk))
+                ->description(sprintf('%.1f%%', ($atRisk / $total) * 100))
+                ->color('warning')
+                ->icon('heroicon-o-exclamation-triangle'),
+
+            Stat::make('Non-Compliant', number_format($nonCompliant))
+                ->description(sprintf('%.1f%%', ($nonCompliant / $total) * 100))
+                ->color('danger')
+                ->icon('heroicon-o-shield-exclamation'),
+        ];
+    }
+}

--- a/app/Filament/Widgets/FccComplianceOverviewWidget.php
+++ b/app/Filament/Widgets/FccComplianceOverviewWidget.php
@@ -11,9 +11,7 @@ class FccComplianceOverviewWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
 
-    protected ?string $heading = 'Compliance at a Glance';
-
-    protected ?string $description = 'Real-time FCC compliance status across all licensed operations';
+    protected static ?string $heading = 'Compliance at a Glance';
 
     protected function getStats(): array
     {

--- a/app/Filament/Widgets/FccLicenseComplianceTableWidget.php
+++ b/app/Filament/Widgets/FccLicenseComplianceTableWidget.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccLicense;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class FccLicenseComplianceTableWidget extends BaseWidget
+{
+    protected static bool $isLazy = false;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'License Compliance';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(FccLicense::query()->orderBy('call_sign'))
+            ->description('Real-time compliance status for all licensed operations')
+            ->columns([
+                TextColumn::make('call_sign')->label('Call Sign')->weight('bold')->searchable()->sortable(),
+                TextColumn::make('licensee')->searchable()->limit(28),
+                TextColumn::make('service')->badge()->color('warning'),
+                TextColumn::make('status')->badge()
+                    ->color(fn ($state) => match ($state) {
+                        'active' => 'success',
+                        'expiring_soon', 'at_risk' => 'warning',
+                        'non_compliant' => 'danger',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn ($state) => str($state)->headline()),
+                TextColumn::make('expiration_date')->date('M d, Y')->label('Expiration')->sortable(),
+                TextColumn::make('compliance_score')
+                    ->label('Compliance Score')
+                    ->suffix('%')
+                    ->sortable()
+                    ->color(fn ($state) => $state >= 95 ? 'success' : ($state >= 80 ? 'warning' : 'danger')),
+            ])
+            ->paginated([10]);
+    }
+}

--- a/app/Filament/Widgets/FccRuleCategoryRollupWidget.php
+++ b/app/Filament/Widgets/FccRuleCategoryRollupWidget.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccLicenseRuleStatus;
+use App\Models\FccRule;
+use Filament\Widgets\Widget;
+use Illuminate\Support\Collection;
+
+class FccRuleCategoryRollupWidget extends Widget
+{
+    protected static bool $isLazy = false;
+
+    protected string $view = 'filament.widgets.fcc-rule-category-rollup';
+
+    protected int|string|array $columnSpan = 1;
+
+    public function getCategoryRows(): Collection
+    {
+        $byCat = FccRule::query()
+            ->select('category', 'id')
+            ->get()
+            ->groupBy('category');
+
+        $rows = collect();
+        foreach ($byCat as $category => $rules) {
+            $ids = $rules->pluck('id');
+            $statuses = FccLicenseRuleStatus::query()
+                ->whereIn('fcc_rule_id', $ids)
+                ->selectRaw('status, COUNT(*) as c')
+                ->groupBy('status')
+                ->pluck('c', 'status');
+
+            $compliant = (int) ($statuses['compliant'] ?? 0);
+            $atRisk = (int) ($statuses['at_risk'] ?? 0);
+            $nonCompliant = (int) ($statuses['non_compliant'] ?? 0);
+            $total = max(1, $compliant + $atRisk + $nonCompliant);
+
+            $rows->push([
+                'category' => $this->formatCategory($category),
+                'compliant' => $compliant,
+                'at_risk' => $atRisk,
+                'non_compliant' => $nonCompliant,
+                'percent' => round(($compliant / $total) * 100, 1),
+            ]);
+        }
+
+        $totalCompliant = $rows->sum('compliant');
+        $totalAtRisk = $rows->sum('at_risk');
+        $totalNon = $rows->sum('non_compliant');
+        $grandTotal = max(1, $totalCompliant + $totalAtRisk + $totalNon);
+
+        $rows->push([
+            'category' => 'TOTAL',
+            'compliant' => $totalCompliant,
+            'at_risk' => $totalAtRisk,
+            'non_compliant' => $totalNon,
+            'percent' => round(($totalCompliant / $grandTotal) * 100, 1),
+            'is_total' => true,
+        ]);
+
+        return $rows;
+    }
+
+    private function formatCategory(string $key): string
+    {
+        return match ($key) {
+            'technical_standards' => 'Technical Standards',
+            'operational_rules' => 'Operational Rules',
+            'eas_requirements' => 'EAS Requirements',
+            'public_file_rules' => 'Public File Rules',
+            'ownership_control' => 'Ownership / Control',
+            'reporting_requirements' => 'Reporting Requirements',
+            default => str($key)->headline()->toString(),
+        };
+    }
+}

--- a/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
+++ b/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\Widgets;
 
-use App\Models\FccLicenseRuleStatus;
+use App\Models\FccRule;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
@@ -19,19 +19,19 @@ class FccTopNonCompliantRulesWidget extends BaseWidget
     {
         return $table
             ->query(
-                FccLicenseRuleStatus::query()
-                    ->whereIn('status', ['non_compliant', 'at_risk'])
-                    ->selectRaw('fcc_rule_id, COUNT(*) as affected_count, MAX(status) as worst_status')
-                    ->groupBy('fcc_rule_id')
+                FccRule::query()
+                    ->withCount([
+                        'statuses as affected_count' => fn ($q) => $q->whereIn('status', ['non_compliant', 'at_risk']),
+                    ])
+                    ->having('affected_count', '>', 0)
                     ->orderByDesc('affected_count')
-                    ->with('rule')
                     ->limit(8)
             )
             ->columns([
-                TextColumn::make('rule.rule_number')->label('FCC Rule')->weight('bold'),
-                TextColumn::make('rule.title')->label('Description')->limit(45),
-                TextColumn::make('affected_count')->label('Affected')->alignRight(),
-                TextColumn::make('rule.severity')->label('Severity')->badge()
+                TextColumn::make('rule_number')->label('FCC Rule')->weight('bold'),
+                TextColumn::make('title')->label('Description')->limit(45),
+                TextColumn::make('affected_count')->label('Affected')->alignment('right'),
+                TextColumn::make('severity')->label('Severity')->badge()
                     ->color(fn ($state) => match ($state) {
                         'critical' => 'danger',
                         'high' => 'warning',

--- a/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
+++ b/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccLicenseRuleStatus;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class FccTopNonCompliantRulesWidget extends BaseWidget
+{
+    protected static bool $isLazy = false;
+
+    protected int|string|array $columnSpan = 1;
+
+    protected static ?string $heading = 'Top Non-Compliant Rules';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                FccLicenseRuleStatus::query()
+                    ->whereIn('status', ['non_compliant', 'at_risk'])
+                    ->selectRaw('fcc_rule_id, COUNT(*) as affected_count, MAX(status) as worst_status')
+                    ->groupBy('fcc_rule_id')
+                    ->orderByDesc('affected_count')
+                    ->with('rule')
+                    ->limit(8)
+            )
+            ->columns([
+                TextColumn::make('rule.rule_number')->label('FCC Rule')->weight('bold'),
+                TextColumn::make('rule.title')->label('Description')->limit(45),
+                TextColumn::make('affected_count')->label('Affected')->alignRight(),
+                TextColumn::make('rule.severity')->label('Severity')->badge()
+                    ->color(fn ($state) => match ($state) {
+                        'critical' => 'danger',
+                        'high' => 'warning',
+                        'medium' => 'info',
+                        default => 'gray',
+                    }),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
+++ b/app/Filament/Widgets/FccTopNonCompliantRulesWidget.php
@@ -20,10 +20,10 @@ class FccTopNonCompliantRulesWidget extends BaseWidget
         return $table
             ->query(
                 FccRule::query()
+                    ->whereHas('statuses', fn ($q) => $q->whereIn('status', ['non_compliant', 'at_risk']))
                     ->withCount([
                         'statuses as affected_count' => fn ($q) => $q->whereIn('status', ['non_compliant', 'at_risk']),
                     ])
-                    ->having('affected_count', '>', 0)
                     ->orderByDesc('affected_count')
                     ->limit(8)
             )

--- a/app/Filament/Widgets/FccUpcomingDeadlinesWidget.php
+++ b/app/Filament/Widgets/FccUpcomingDeadlinesWidget.php
@@ -13,7 +13,7 @@ class FccUpcomingDeadlinesWidget extends BaseWidget
 
     protected int|string|array $columnSpan = 'full';
 
-    protected ?string $heading = 'Upcoming FCC Deadlines';
+    protected static ?string $heading = 'Upcoming FCC Deadlines';
 
     public function table(Table $table): Table
     {

--- a/app/Filament/Widgets/FccUpcomingDeadlinesWidget.php
+++ b/app/Filament/Widgets/FccUpcomingDeadlinesWidget.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\FccDeadline;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+
+class FccUpcomingDeadlinesWidget extends BaseWidget
+{
+    protected static bool $isLazy = false;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected ?string $heading = 'Upcoming FCC Deadlines';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                FccDeadline::query()
+                    ->whereIn('status', ['upcoming', 'due_soon', 'overdue'])
+                    ->orderBy('due_date')
+                    ->limit(10)
+            )
+            ->columns([
+                TextColumn::make('due_date')->date('M d, Y')->label('Date')->sortable(),
+                TextColumn::make('title')->weight('bold')->limit(60),
+                TextColumn::make('deadline_type')->badge()
+                    ->formatStateUsing(fn ($s) => str($s)->headline()),
+                TextColumn::make('license.call_sign')->label('Call Sign'),
+                TextColumn::make('due_date')
+                    ->label('Days')
+                    ->state(fn (FccDeadline $r) => max(0, (int) now()->startOfDay()->diffInDays($r->due_date->startOfDay(), false)).' days'),
+                TextColumn::make('status')->badge()->color(fn ($s) => match ($s) {
+                    'upcoming' => 'gray', 'due_soon' => 'warning',
+                    'overdue' => 'danger', 'completed' => 'success', default => 'gray',
+                })->formatStateUsing(fn ($s) => str($s)->headline()),
+            ])
+            ->paginated(false);
+    }
+}

--- a/app/Http/Controllers/FccComplianceReportController.php
+++ b/app/Http/Controllers/FccComplianceReportController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\FccLicense;
+use App\Models\FccLicenseRuleStatus;
+use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class FccComplianceReportController extends Controller
+{
+    /**
+     * Stream a CSV summary suitable for sharing with FCC compliance leadership.
+     * Columns mirror the dashboard: per-license + per-rule-category rollup.
+     */
+    public function csv(): StreamedResponse
+    {
+        $filename = 'fcc-compliance-report-'.now()->format('Y-m-d-His').'.csv';
+
+        return response()->streamDownload(function () {
+            $out = fopen('php://output', 'w');
+
+            // Header section
+            fputcsv($out, ['OpenGRC FCC Compliance — Report']);
+            fputcsv($out, ['Generated', now()->toIso8601String()]);
+            fputcsv($out, []);
+
+            // License summary
+            fputcsv($out, ['License Compliance']);
+            fputcsv($out, [
+                'Call Sign', 'FRN', 'Licensee', 'Service', 'Channel/Frequency',
+                'Status', 'Expiration', 'Compliance Score (%)',
+            ]);
+            foreach (FccLicense::query()->orderBy('call_sign')->get() as $license) {
+                fputcsv($out, [
+                    $license->call_sign,
+                    $license->frn,
+                    $license->licensee,
+                    $license->service,
+                    $license->channel_or_frequency,
+                    str($license->status)->headline(),
+                    optional($license->expiration_date)->format('Y-m-d'),
+                    $license->compliance_score,
+                ]);
+            }
+            fputcsv($out, []);
+
+            // Rule status rollup per license
+            fputcsv($out, ['Rule Status by License']);
+            fputcsv($out, ['Call Sign', 'CFR Section', 'Rule Title', 'Category', 'Severity', 'Status', 'Last Evaluated', 'Notes']);
+            FccLicenseRuleStatus::query()
+                ->with(['license', 'rule'])
+                ->orderBy('license_id')
+                ->orderByDesc('status')
+                ->chunk(500, function ($rows) use ($out) {
+                    foreach ($rows as $row) {
+                        if (! $row->license || ! $row->rule) continue;
+                        fputcsv($out, [
+                            $row->license->call_sign,
+                            $row->rule->rule_number,
+                            $row->rule->title,
+                            str($row->rule->category)->headline(),
+                            ucfirst($row->rule->severity),
+                            str($row->status)->headline(),
+                            optional($row->last_evaluated_at)->format('Y-m-d'),
+                            $row->evaluation_notes,
+                        ]);
+                    }
+                });
+
+            fclose($out);
+        }, $filename, [
+            'Content-Type' => 'text/csv',
+            'Cache-Control' => 'no-cache, no-store, must-revalidate',
+        ]);
+    }
+}

--- a/app/Models/FccAsrRegistration.php
+++ b/app/Models/FccAsrRegistration.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FccAsrRegistration extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'fcc_asr_registrations';
+
+    protected $fillable = [
+        'asr_number', 'owner', 'structure_type', 'overall_height_meters',
+        'latitude', 'longitude', 'faa_study_number', 'lighting_type',
+        'painting_required', 'last_inspection_date', 'next_inspection_due',
+    ];
+
+    protected $casts = [
+        'overall_height_meters' => 'decimal:2',
+        'latitude' => 'decimal:6',
+        'longitude' => 'decimal:6',
+        'last_inspection_date' => 'date',
+        'next_inspection_due' => 'date',
+    ];
+
+    public function inspections(): HasMany
+    {
+        return $this->hasMany(FccTowerLightingInspection::class, 'asr_registration_id');
+    }
+
+    public function outages(): HasMany
+    {
+        return $this->hasMany(FccTowerLightingOutage::class, 'asr_registration_id');
+    }
+}

--- a/app/Models/FccComplianceEvent.php
+++ b/app/Models/FccComplianceEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccComplianceEvent extends Model
+{
+    protected $table = 'fcc_compliance_events';
+
+    protected $fillable = [
+        'license_id', 'event_type', 'summary', 'payload', 'actor', 'occurred_at',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'occurred_at' => 'datetime',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccDeadline.php
+++ b/app/Models/FccDeadline.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccDeadline extends Model
+{
+    protected $table = 'fcc_deadlines';
+
+    protected $fillable = [
+        'license_id', 'title', 'deadline_type', 'due_date', 'status', 'notes',
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+
+    public function getDaysUntilDueAttribute(): int
+    {
+        return now()->startOfDay()->diffInDays($this->due_date->startOfDay(), false);
+    }
+}

--- a/app/Models/FccEasTest.php
+++ b/app/Models/FccEasTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccEasTest extends Model
+{
+    protected $table = 'fcc_eas_tests';
+
+    protected $fillable = [
+        'license_id', 'test_type', 'direction', 'test_datetime',
+        'originator_code', 'event_code', 'location_codes',
+        'audio_intelligible', 'visual_message_present',
+        'comments', 'filed_in_etrs', 'etrs_filed_date', 'logged_by',
+    ];
+
+    protected $casts = [
+        'test_datetime' => 'datetime',
+        'audio_intelligible' => 'boolean',
+        'visual_message_present' => 'boolean',
+        'filed_in_etrs' => 'boolean',
+        'etrs_filed_date' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccFacility.php
+++ b/app/Models/FccFacility.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FccFacility extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'fcc_facilities';
+
+    protected $fillable = [
+        'facility_id', 'name', 'community_of_license', 'state',
+        'latitude', 'longitude', 'antenna_haat_meters', 'antenna_amsl_meters',
+        'asr_number', 'owner', 'contact_engineer', 'notes',
+    ];
+
+    protected $casts = [
+        'latitude' => 'decimal:6',
+        'longitude' => 'decimal:6',
+        'antenna_haat_meters' => 'decimal:2',
+        'antenna_amsl_meters' => 'decimal:2',
+    ];
+
+    public function licenses(): HasMany
+    {
+        return $this->hasMany(FccLicense::class, 'facility_id');
+    }
+}

--- a/app/Models/FccFormFiling.php
+++ b/app/Models/FccFormFiling.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccFormFiling extends Model
+{
+    protected $table = 'fcc_form_filings';
+
+    protected $fillable = [
+        'license_id', 'form_number', 'form_title', 'filed_date',
+        'file_number', 'status', 'notes', 'filed_by',
+    ];
+
+    protected $casts = [
+        'filed_date' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccIssuesProgramsEntry.php
+++ b/app/Models/FccIssuesProgramsEntry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccIssuesProgramsEntry extends Model
+{
+    protected $table = 'fcc_issues_programs_entries';
+
+    protected $fillable = [
+        'list_id', 'issue', 'program_title', 'program_description',
+        'aired_at', 'duration_minutes', 'program_type',
+    ];
+
+    protected $casts = [
+        'aired_at' => 'datetime',
+    ];
+
+    public function list(): BelongsTo
+    {
+        return $this->belongsTo(FccIssuesProgramsList::class, 'list_id');
+    }
+}

--- a/app/Models/FccIssuesProgramsList.php
+++ b/app/Models/FccIssuesProgramsList.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class FccIssuesProgramsList extends Model
+{
+    protected $table = 'fcc_issues_programs_lists';
+
+    protected $fillable = [
+        'license_id', 'quarter_year', 'quarter',
+        'placed_in_file_date', 'status', 'preparer_notes',
+    ];
+
+    protected $casts = [
+        'placed_in_file_date' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(FccIssuesProgramsEntry::class, 'list_id');
+    }
+}

--- a/app/Models/FccLicense.php
+++ b/app/Models/FccLicense.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FccLicense extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'fcc_licenses';
+
+    protected $fillable = [
+        'frn', 'call_sign', 'licensee', 'service', 'channel_or_frequency',
+        'grant_date', 'expiration_date', 'last_renewal_date', 'status',
+        'compliance_score', 'facility_id', 'license_class_data', 'public_notes',
+    ];
+
+    protected $casts = [
+        'grant_date' => 'date',
+        'expiration_date' => 'date',
+        'last_renewal_date' => 'date',
+        'compliance_score' => 'decimal:2',
+        'license_class_data' => 'array',
+    ];
+
+    public function facility(): BelongsTo
+    {
+        return $this->belongsTo(FccFacility::class, 'facility_id');
+    }
+
+    public function transmitters(): HasMany
+    {
+        return $this->hasMany(FccTransmitter::class, 'license_id');
+    }
+
+    public function ruleStatuses(): HasMany
+    {
+        return $this->hasMany(FccLicenseRuleStatus::class, 'license_id');
+    }
+
+    public function rules(): BelongsToMany
+    {
+        return $this->belongsToMany(FccRule::class, 'fcc_license_rule_status', 'license_id', 'fcc_rule_id')
+            ->withPivot(['status', 'last_evaluated_at', 'evaluation_notes', 'evidence_path'])
+            ->withTimestamps();
+    }
+
+    public function deadlines(): HasMany
+    {
+        return $this->hasMany(FccDeadline::class, 'license_id');
+    }
+
+    public function complianceEvents(): HasMany
+    {
+        return $this->hasMany(FccComplianceEvent::class, 'license_id');
+    }
+
+    public function getStatusColorAttribute(): string
+    {
+        return match ($this->status) {
+            'active' => 'success',
+            'expiring_soon' => 'warning',
+            'at_risk' => 'warning',
+            'non_compliant' => 'danger',
+            'silent', 'cancelled' => 'gray',
+            default => 'gray',
+        };
+    }
+}

--- a/app/Models/FccLicenseRuleStatus.php
+++ b/app/Models/FccLicenseRuleStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccLicenseRuleStatus extends Model
+{
+    protected $table = 'fcc_license_rule_status';
+
+    protected $fillable = [
+        'license_id', 'fcc_rule_id', 'status',
+        'last_evaluated_at', 'evaluation_notes', 'evidence_path',
+    ];
+
+    protected $casts = [
+        'last_evaluated_at' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+
+    public function rule(): BelongsTo
+    {
+        return $this->belongsTo(FccRule::class, 'fcc_rule_id');
+    }
+}

--- a/app/Models/FccPoliticalFileEntry.php
+++ b/app/Models/FccPoliticalFileEntry.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccPoliticalFileEntry extends Model
+{
+    protected $table = 'fcc_political_file_entries';
+
+    protected $fillable = [
+        'license_id', 'order_date', 'candidate_or_issue', 'sponsor', 'office',
+        'flight_start_date', 'flight_end_date', 'spots_purchased',
+        'rate_per_spot', 'total_amount', 'lowest_unit_rate_window',
+        'contract_pdf_path', 'uploaded_to_public_file_date',
+    ];
+
+    protected $casts = [
+        'order_date' => 'date',
+        'flight_start_date' => 'date',
+        'flight_end_date' => 'date',
+        'uploaded_to_public_file_date' => 'date',
+        'rate_per_spot' => 'decimal:2',
+        'total_amount' => 'decimal:2',
+        'lowest_unit_rate_window' => 'boolean',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccPublicFileDocument.php
+++ b/app/Models/FccPublicFileDocument.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FccPublicFileDocument extends Model
+{
+    use SoftDeletes;
+
+    protected $table = 'fcc_public_file_documents';
+
+    protected $fillable = [
+        'license_id', 'document_type', 'title',
+        'document_date', 'uploaded_to_lms_date', 'retention_until',
+        'lms_url', 'notes', 'uploaded_by',
+    ];
+
+    protected $casts = [
+        'document_date' => 'date',
+        'uploaded_to_lms_date' => 'date',
+        'retention_until' => 'date',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccRegulatoryFee.php
+++ b/app/Models/FccRegulatoryFee.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccRegulatoryFee extends Model
+{
+    protected $table = 'fcc_regulatory_fees';
+
+    protected $fillable = [
+        'license_id', 'fiscal_year', 'fee_category',
+        'amount_due', 'amount_paid', 'due_date', 'paid_date',
+        'confirmation_number', 'status',
+    ];
+
+    protected $casts = [
+        'due_date' => 'date',
+        'paid_date' => 'date',
+        'amount_due' => 'decimal:2',
+        'amount_paid' => 'decimal:2',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccRule.php
+++ b/app/Models/FccRule.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class FccRule extends Model
+{
+    use HasFactory;
+
+    protected $table = 'fcc_rules';
+
+    protected $fillable = [
+        'rule_number', 'part', 'title', 'description',
+        'category', 'severity', 'quarterly_filing_required',
+    ];
+
+    protected $casts = [
+        'quarterly_filing_required' => 'boolean',
+    ];
+
+    public function licenses(): BelongsToMany
+    {
+        return $this->belongsToMany(FccLicense::class, 'fcc_license_rule_status', 'fcc_rule_id', 'license_id')
+            ->withPivot(['status', 'last_evaluated_at', 'evaluation_notes', 'evidence_path'])
+            ->withTimestamps();
+    }
+
+    public function statuses(): HasMany
+    {
+        return $this->hasMany(FccLicenseRuleStatus::class, 'fcc_rule_id');
+    }
+}

--- a/app/Models/FccStationLogEntry.php
+++ b/app/Models/FccStationLogEntry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccStationLogEntry extends Model
+{
+    protected $table = 'fcc_station_log_entries';
+
+    protected $fillable = [
+        'license_id', 'logged_at', 'entry_type', 'summary', 'readings', 'logged_by',
+    ];
+
+    protected $casts = [
+        'logged_at' => 'datetime',
+        'readings' => 'array',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Models/FccTowerLightingInspection.php
+++ b/app/Models/FccTowerLightingInspection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccTowerLightingInspection extends Model
+{
+    protected $table = 'fcc_tower_lighting_inspections';
+
+    protected $fillable = [
+        'asr_registration_id', 'facility_id', 'inspection_date',
+        'inspector_name', 'result', 'automatic_monitor_observed',
+        'manual_observation_performed', 'findings', 'corrective_action',
+        'next_inspection_due',
+    ];
+
+    protected $casts = [
+        'inspection_date' => 'date',
+        'next_inspection_due' => 'date',
+        'automatic_monitor_observed' => 'boolean',
+        'manual_observation_performed' => 'boolean',
+    ];
+
+    public function asr(): BelongsTo
+    {
+        return $this->belongsTo(FccAsrRegistration::class, 'asr_registration_id');
+    }
+
+    public function facility(): BelongsTo
+    {
+        return $this->belongsTo(FccFacility::class, 'facility_id');
+    }
+}

--- a/app/Models/FccTowerLightingOutage.php
+++ b/app/Models/FccTowerLightingOutage.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FccTowerLightingOutage extends Model
+{
+    protected $table = 'fcc_tower_lighting_outages';
+
+    protected $fillable = [
+        'asr_registration_id', 'outage_observed_at', 'faa_notified_at',
+        'notam_number', 'repaired_at', 'faa_cancellation_at',
+        'failure_type', 'cause', 'actions_taken',
+    ];
+
+    protected $casts = [
+        'outage_observed_at' => 'datetime',
+        'faa_notified_at' => 'datetime',
+        'repaired_at' => 'datetime',
+        'faa_cancellation_at' => 'datetime',
+    ];
+
+    public function asr(): BelongsTo
+    {
+        return $this->belongsTo(FccAsrRegistration::class, 'asr_registration_id');
+    }
+}

--- a/app/Models/FccTransmitter.php
+++ b/app/Models/FccTransmitter.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class FccTransmitter extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'fcc_transmitters';
+
+    protected $fillable = [
+        'license_id', 'manufacturer', 'model', 'serial_number',
+        'rated_power_kw', 'authorized_erp_kw', 'measured_power_kw',
+        'last_proof_of_performance', 'next_proof_due',
+        'eas_endec_present', 'eas_endec_model', 'status', 'notes',
+    ];
+
+    protected $casts = [
+        'rated_power_kw' => 'decimal:3',
+        'authorized_erp_kw' => 'decimal:3',
+        'measured_power_kw' => 'decimal:3',
+        'last_proof_of_performance' => 'date',
+        'next_proof_due' => 'date',
+        'eas_endec_present' => 'boolean',
+    ];
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(FccLicense::class, 'license_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,22 @@ class AppServiceProvider extends ServiceProvider
         // Disable mass assignment protection
         Model::unguard();
 
+        // Put SQLite into WAL + sane PRAGMAs on every connection.
+        // Without WAL, long-running imports (e.g. fcc:import-lms) take
+        // a write lock and block every web request reading the DB —
+        // pages just sit at the splash logo until the writer finishes.
+        if (config('database.default') === 'sqlite') {
+            \Illuminate\Support\Facades\DB::listen(function () {});
+            try {
+                $pdo = \Illuminate\Support\Facades\DB::connection()->getPdo();
+                $pdo->exec('PRAGMA journal_mode = WAL');
+                $pdo->exec('PRAGMA synchronous = NORMAL');
+                $pdo->exec('PRAGMA busy_timeout = 5000');
+            } catch (\Throwable $e) {
+                // First-boot, DB may not exist yet — ignore.
+            }
+        }
+
         // Only skip the install check if running the installer command or actual PHPUnit tests
         $isInstaller = false;
         if ($this->app->runningInConsole()) {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -57,6 +57,7 @@ class AdminPanelProvider extends PanelProvider
                 'danger' => Color::hex('#ef4444'),
             ])
             ->brandName(name: 'OpenGRC FCC Compliance Admin')
+            ->defaultThemeMode(\Filament\Enums\ThemeMode::Dark)
             ->viteTheme('resources/css/filament/app/theme.css')
             ->brandLogo(fn () => view('filament.admin.logo'))
             ->globalSearch(true)

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -49,9 +49,14 @@ class AdminPanelProvider extends PanelProvider
             ->path('admin')
             ->loginRouteSlug('login')
             ->colors([
-                'primary' => Color::Slate,
+                'primary' => Color::hex('#fbbf24'),
+                'gray' => Color::hex('#0c1f3d'),
+                'info' => Color::hex('#22d3ee'),
+                'success' => Color::hex('#22c55e'),
+                'warning' => Color::hex('#f59e0b'),
+                'danger' => Color::hex('#ef4444'),
             ])
-            ->brandName(name: 'OpenGRC Admin')
+            ->brandName(name: 'OpenGRC FCC Compliance Admin')
             ->viteTheme('resources/css/filament/app/theme.css')
             ->brandLogo(fn () => view('filament.admin.logo'))
             ->globalSearch(true)
@@ -120,7 +125,7 @@ class AdminPanelProvider extends PanelProvider
                 fn () => view('components.session-expiration-handler')
             )
             ->navigationItems([
-                NavigationItem::make('Back to OpenGRC')
+                NavigationItem::make('Back to OpenGRC FCC Compliance')
                     ->url('/app', shouldOpenInNewTab: false)
                     ->icon('heroicon-o-arrow-left'),
             ]);

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -157,6 +157,10 @@ class AppPanelProvider extends PanelProvider
                 PanelsRenderHook::SIDEBAR_FOOTER,
                 fn () => view('filament.app.sidebar-bottom-links')
             )
+            ->renderHook(
+                PanelsRenderHook::FOOTER,
+                fn () => view('filament.footer.fcc-compliance-strip')
+            )
             ->navigationGroups([
                 'Foundations',
                 'Entities',

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -161,6 +161,14 @@ class AppPanelProvider extends PanelProvider
                 PanelsRenderHook::FOOTER,
                 fn () => view('filament.footer.fcc-compliance-strip')
             )
+            ->renderHook(
+                PanelsRenderHook::TOPBAR_END,
+                fn () => view('filament.topbar.fcc-alerts-badge')
+            )
+            ->renderHook(
+                PanelsRenderHook::TOPBAR_END,
+                fn () => view('filament.topbar.fcc-export-button')
+            )
             ->navigationGroups([
                 'FCC Compliance',
                 'FCC Compliance Review',

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -108,6 +108,7 @@ class AppPanelProvider extends PanelProvider
                 'danger' => Color::hex('#ef4444'),
             ])
             ->brandName('OpenGRC FCC Compliance')
+            ->defaultThemeMode(\Filament\Enums\ThemeMode::Dark)
             ->brandLogo(fn () => view('filament.admin.logo'))
             ->globalSearch(true)
             ->databaseNotifications()

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -100,9 +100,14 @@ class AppPanelProvider extends PanelProvider
             ->login(Login::class)
             ->loginRouteSlug('login')
             ->colors([
-                'primary' => Color::Slate,
+                'primary' => Color::hex('#fbbf24'),
+                'gray' => Color::hex('#0c1f3d'),
+                'info' => Color::hex('#22d3ee'),
+                'success' => Color::hex('#22c55e'),
+                'warning' => Color::hex('#f59e0b'),
+                'danger' => Color::hex('#ef4444'),
             ])
-            ->brandName('OpenGRC')
+            ->brandName('OpenGRC FCC Compliance')
             ->brandLogo(fn () => view('filament.admin.logo'))
             ->globalSearch(true)
             ->databaseNotifications()
@@ -115,6 +120,10 @@ class AppPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
+            ->widgets([
+                \App\Filament\Widgets\FccComplianceOverviewWidget::class,
+                \App\Filament\Widgets\FccUpcomingDeadlinesWidget::class,
+            ])
             ->plugins([
                 FilamentApexChartsPlugin::make(),
                 BreezyCore::make()

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -162,8 +162,12 @@ class AppPanelProvider extends PanelProvider
                 fn () => view('filament.footer.fcc-compliance-strip')
             )
             ->navigationGroups([
+                'FCC Compliance',
+                'FCC Compliance Review',
+                'Documents & Reports',
                 'Foundations',
                 'Entities',
+                'Admin',
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/app/Providers/Filament/TrustCenterPanelProvider.php
+++ b/app/Providers/Filament/TrustCenterPanelProvider.php
@@ -24,7 +24,8 @@ class TrustCenterPanelProvider extends PanelProvider
             ->id('trustcenter')
             ->path('trust')
             ->colors([
-                'primary' => Color::Blue,
+                'primary' => Color::hex('#fbbf24'),
+                'gray' => Color::hex('#0c1f3d'),
             ])
             ->brandName($this->getTrustCenterName())
             ->spa()

--- a/app/Providers/Filament/VendorPanelProvider.php
+++ b/app/Providers/Filament/VendorPanelProvider.php
@@ -36,7 +36,8 @@ class VendorPanelProvider extends PanelProvider
             ->emailVerification()
             ->profile()
             ->colors([
-                'primary' => Color::Teal,
+                'primary' => Color::hex('#fbbf24'),
+                'gray' => Color::hex('#0c1f3d'),
             ])
             ->brandName($this->getPortalName())
             ->spa()

--- a/database/migrations/2026_05_04_000001_create_fcc_compliance_tables.php
+++ b/database/migrations/2026_05_04_000001_create_fcc_compliance_tables.php
@@ -1,0 +1,146 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fcc_facilities', function (Blueprint $table) {
+            $table->id();
+            $table->string('facility_id')->unique()->comment('FCC Facility ID (FRN-style)');
+            $table->string('name');
+            $table->string('community_of_license')->nullable();
+            $table->string('state', 2)->nullable();
+            $table->decimal('latitude', 10, 6)->nullable();
+            $table->decimal('longitude', 10, 6)->nullable();
+            $table->decimal('antenna_haat_meters', 8, 2)->nullable()->comment('Height Above Average Terrain');
+            $table->decimal('antenna_amsl_meters', 8, 2)->nullable()->comment('Above Mean Sea Level');
+            $table->string('asr_number')->nullable()->comment('Antenna Structure Registration #');
+            $table->string('owner')->nullable();
+            $table->string('contact_engineer')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('fcc_licenses', function (Blueprint $table) {
+            $table->id();
+            $table->string('frn')->index()->comment('FCC Registration Number');
+            $table->string('call_sign')->unique();
+            $table->string('licensee');
+            $table->enum('service', [
+                'AM', 'FM', 'TV', 'LPFM', 'LPTV', 'FX', 'TX', 'DT', 'DC', 'DD', 'CA', 'OTHER'
+            ])->default('FM')->comment('FCC service code');
+            $table->string('channel_or_frequency')->nullable()->comment('e.g. 98.7 MHz, Ch. 27');
+            $table->date('grant_date')->nullable();
+            $table->date('expiration_date')->nullable();
+            $table->date('last_renewal_date')->nullable();
+            $table->enum('status', ['active', 'expiring_soon', 'at_risk', 'non_compliant', 'silent', 'cancelled'])
+                ->default('active');
+            $table->decimal('compliance_score', 5, 2)->default(100.00)->comment('0-100 derived score');
+            $table->foreignId('facility_id')->nullable()->constrained('fcc_facilities')->nullOnDelete();
+            $table->json('license_class_data')->nullable()->comment('Class A/B/C, ERP kW, etc.');
+            $table->text('public_notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['status']);
+            $table->index(['expiration_date']);
+        });
+
+        Schema::create('fcc_transmitters', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->string('manufacturer')->nullable();
+            $table->string('model')->nullable();
+            $table->string('serial_number')->nullable();
+            $table->decimal('rated_power_kw', 8, 3)->nullable();
+            $table->decimal('authorized_erp_kw', 8, 3)->nullable()->comment('Effective Radiated Power');
+            $table->decimal('measured_power_kw', 8, 3)->nullable();
+            $table->date('last_proof_of_performance')->nullable();
+            $table->date('next_proof_due')->nullable();
+            $table->boolean('eas_endec_present')->default(false);
+            $table->string('eas_endec_model')->nullable();
+            $table->enum('status', ['operating', 'standby', 'offline', 'maintenance'])->default('operating');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('fcc_rules', function (Blueprint $table) {
+            $table->id();
+            $table->string('rule_number')->unique()->comment('e.g. 73.3526, 73.1212');
+            $table->string('part')->nullable()->comment('e.g. Part 73, Part 11');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->enum('category', [
+                'technical_standards', 'operational_rules', 'eas_requirements',
+                'public_file_rules', 'ownership_control', 'reporting_requirements'
+            ])->default('operational_rules');
+            $table->enum('severity', ['low', 'medium', 'high', 'critical'])->default('medium');
+            $table->boolean('quarterly_filing_required')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('fcc_license_rule_status', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->foreignId('fcc_rule_id')->constrained('fcc_rules')->cascadeOnDelete();
+            $table->enum('status', ['compliant', 'at_risk', 'non_compliant', 'not_applicable'])
+                ->default('compliant');
+            $table->date('last_evaluated_at')->nullable();
+            $table->text('evaluation_notes')->nullable();
+            $table->string('evidence_path')->nullable();
+            $table->timestamps();
+
+            $table->unique(['license_id', 'fcc_rule_id']);
+            $table->index(['status']);
+        });
+
+        Schema::create('fcc_deadlines', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->nullable()->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->string('title');
+            $table->enum('deadline_type', [
+                'quarterly_eas_test', 'public_file_upload', 'license_renewal',
+                'issues_programs_list', 'ownership_report', 'eeo_report',
+                'children_tv_report', 'tower_lighting', 'other'
+            ])->default('other');
+            $table->date('due_date');
+            $table->enum('status', ['upcoming', 'due_soon', 'overdue', 'completed'])->default('upcoming');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index(['due_date']);
+            $table->index(['status']);
+        });
+
+        Schema::create('fcc_compliance_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->nullable()->constrained('fcc_licenses')->nullOnDelete();
+            $table->string('event_type')->comment('e.g. eas_test_filed, public_file_uploaded, technical_review_passed');
+            $table->string('summary');
+            $table->json('payload')->nullable();
+            $table->string('actor')->nullable()->comment('user/email/system');
+            $table->timestamp('occurred_at')->useCurrent();
+            $table->timestamps();
+
+            $table->index(['event_type']);
+            $table->index(['occurred_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fcc_compliance_events');
+        Schema::dropIfExists('fcc_deadlines');
+        Schema::dropIfExists('fcc_license_rule_status');
+        Schema::dropIfExists('fcc_rules');
+        Schema::dropIfExists('fcc_transmitters');
+        Schema::dropIfExists('fcc_licenses');
+        Schema::dropIfExists('fcc_facilities');
+    }
+};

--- a/database/migrations/2026_05_04_010000_create_fcc_operational_tables.php
+++ b/database/migrations/2026_05_04_010000_create_fcc_operational_tables.php
@@ -1,0 +1,239 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // ASR — Antenna Structure Registration (47 CFR Part 17)
+        // Towers >200ft AGL or near airports must be ASR-registered with the FCC.
+        Schema::create('fcc_asr_registrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('asr_number')->unique()->comment('FCC ASR # (7 digits)');
+            $table->string('owner');
+            $table->string('structure_type')->nullable()->comment('Guyed, Self-supporting, Monopole, Building');
+            $table->decimal('overall_height_meters', 8, 2)->nullable()->comment('Above ground level');
+            $table->decimal('latitude', 10, 6)->nullable();
+            $table->decimal('longitude', 10, 6)->nullable();
+            $table->string('faa_study_number')->nullable()->comment('FAA aeronautical study');
+            $table->enum('lighting_type', ['none', 'red_only', 'medium_dual', 'high_dual', 'medium_white', 'high_white'])
+                ->nullable();
+            $table->enum('painting_required', ['none', 'aviation_orange_white'])->nullable();
+            $table->date('last_inspection_date')->nullable();
+            $table->date('next_inspection_due')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        // EAS Tests — required by 47 CFR Part 11
+        // RWT (weekly), RMT (monthly), NPT (annual national test)
+        Schema::create('fcc_eas_tests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->enum('test_type', ['RWT', 'RMT', 'NPT', 'state_test'])
+                ->comment('Required Weekly/Monthly Test, National Periodic Test, State');
+            $table->enum('direction', ['received', 'originated'])->default('received');
+            $table->dateTime('test_datetime');
+            $table->string('originator_code', 8)->nullable()->comment('EAS originator (e.g. EAN, PEP, EAS, CIV, WXR)');
+            $table->string('event_code', 8)->nullable()->comment('e.g. RWT, RMT, EAS, EAN, NPT');
+            $table->string('location_codes')->nullable()->comment('FIPS codes received');
+            $table->boolean('audio_intelligible')->nullable();
+            $table->boolean('visual_message_present')->nullable();
+            $table->text('comments')->nullable();
+            $table->boolean('filed_in_etrs')->default(false)->comment('Filed in FCC ETRS');
+            $table->date('etrs_filed_date')->nullable();
+            $table->string('logged_by')->nullable();
+            $table->timestamps();
+
+            $table->index(['license_id', 'test_datetime']);
+            $table->index(['test_type']);
+        });
+
+        // Issues/Programs Lists — quarterly per 47 CFR §73.3526(e)(12)
+        // Top community issues + programs that addressed them. Filed within 10 days of quarter end.
+        Schema::create('fcc_issues_programs_lists', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->year('quarter_year');
+            $table->enum('quarter', ['Q1', 'Q2', 'Q3', 'Q4']);
+            $table->date('placed_in_file_date')->nullable();
+            $table->enum('status', ['draft', 'placed_in_file', 'late_filed'])->default('draft');
+            $table->text('preparer_notes')->nullable();
+            $table->timestamps();
+
+            $table->unique(['license_id', 'quarter_year', 'quarter']);
+        });
+
+        Schema::create('fcc_issues_programs_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('list_id')->constrained('fcc_issues_programs_lists')->cascadeOnDelete();
+            $table->string('issue')->comment('Community issue addressed (e.g. Mental Health, Local Economy)');
+            $table->string('program_title');
+            $table->string('program_description', 1000)->nullable();
+            $table->dateTime('aired_at')->nullable();
+            $table->unsignedInteger('duration_minutes')->nullable();
+            $table->enum('program_type', ['news', 'public_affairs', 'pia', 'documentary', 'interview', 'other'])
+                ->default('public_affairs');
+            $table->timestamps();
+        });
+
+        // Public File Documents — online inspection file (47 CFR §73.3526)
+        Schema::create('fcc_public_file_documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->enum('document_type', [
+                'authorization', 'application', 'contour_map', 'ownership_report',
+                'eeo_public_file', 'political_file', 'issues_programs_list',
+                'children_tv_report', 'shared_service_agreement', 'time_brokerage_agreement',
+                'joint_sales_agreement', 'biennial_ownership_report',
+                'donor_list', 'station_id_announcement', 'public_notice', 'letter_to_public',
+                'other',
+            ]);
+            $table->string('title');
+            $table->date('document_date')->nullable();
+            $table->date('uploaded_to_lms_date')->nullable()->comment('Filed in FCC LMS');
+            $table->date('retention_until')->nullable()->comment('Required retention end (typically license term)');
+            $table->string('lms_url')->nullable();
+            $table->text('notes')->nullable();
+            $table->string('uploaded_by')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['license_id', 'document_type']);
+        });
+
+        // Tower Lighting Inspections — quarterly per 47 CFR §17.47
+        Schema::create('fcc_tower_lighting_inspections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asr_registration_id')->nullable()->constrained('fcc_asr_registrations')->nullOnDelete();
+            $table->foreignId('facility_id')->nullable()->constrained('fcc_facilities')->nullOnDelete();
+            $table->date('inspection_date');
+            $table->string('inspector_name')->nullable();
+            $table->enum('result', ['operational', 'minor_issue', 'failed'])->default('operational');
+            $table->boolean('automatic_monitor_observed')->default(true)->comment('Auto-alarm system verified');
+            $table->boolean('manual_observation_performed')->default(true)->comment('§17.47 24-hour observation');
+            $table->text('findings')->nullable();
+            $table->text('corrective_action')->nullable();
+            $table->date('next_inspection_due');
+            $table->timestamps();
+
+            $table->index(['inspection_date']);
+        });
+
+        // Tower Lighting Outage NOTAMs — 47 CFR §17.48 requires immediate FAA notification
+        Schema::create('fcc_tower_lighting_outages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asr_registration_id')->constrained('fcc_asr_registrations')->cascadeOnDelete();
+            $table->dateTime('outage_observed_at');
+            $table->dateTime('faa_notified_at')->nullable()->comment('Required within reasonable time');
+            $table->string('notam_number')->nullable()->comment('FAA NOTAM identifier');
+            $table->dateTime('repaired_at')->nullable();
+            $table->dateTime('faa_cancellation_at')->nullable();
+            $table->enum('failure_type', ['top_beacon', 'side_marker', 'monitor_alarm', 'partial', 'total'])
+                ->default('partial');
+            $table->text('cause')->nullable();
+            $table->text('actions_taken')->nullable();
+            $table->timestamps();
+
+            $table->index(['outage_observed_at']);
+        });
+
+        // Political File — political ad tracking (47 CFR §73.1943, §76.1701)
+        Schema::create('fcc_political_file_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->date('order_date');
+            $table->string('candidate_or_issue')->comment('Candidate name or ballot issue');
+            $table->string('sponsor')->comment('Buying entity (committee, PAC, candidate)');
+            $table->enum('office', [
+                'federal_president', 'federal_senate', 'federal_house',
+                'state_governor', 'state_legislature', 'state_other',
+                'local', 'ballot_initiative', 'issue_ad',
+            ])->nullable();
+            $table->date('flight_start_date')->nullable();
+            $table->date('flight_end_date')->nullable();
+            $table->unsignedInteger('spots_purchased')->nullable();
+            $table->decimal('rate_per_spot', 10, 2)->nullable();
+            $table->decimal('total_amount', 12, 2)->nullable();
+            $table->boolean('lowest_unit_rate_window')->default(false)
+                ->comment('LUR applies: 45d before primary / 60d before general');
+            $table->string('contract_pdf_path')->nullable();
+            $table->date('uploaded_to_public_file_date')->nullable();
+            $table->timestamps();
+
+            $table->index(['license_id', 'order_date']);
+        });
+
+        // Station Log — daily operational entries (47 CFR §73.1820)
+        Schema::create('fcc_station_log_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->dateTime('logged_at');
+            $table->enum('entry_type', [
+                'transmitter_reading', 'eas_test', 'tower_lighting_check',
+                'sign_on', 'sign_off', 'station_id', 'maintenance',
+                'power_change', 'directional_pattern_check', 'incident', 'other',
+            ]);
+            $table->string('summary');
+            $table->json('readings')->nullable()->comment('e.g. {"power_kw":50.1, "swr":1.05}');
+            $table->string('logged_by')->nullable();
+            $table->timestamps();
+
+            $table->index(['license_id', 'logged_at']);
+            $table->index(['entry_type']);
+        });
+
+        // Regulatory Fees — annual per FCC Form 159
+        Schema::create('fcc_regulatory_fees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->year('fiscal_year');
+            $table->string('fee_category')->comment('e.g. AM Class A, FM Class C, TV Markets 1-10');
+            $table->decimal('amount_due', 10, 2);
+            $table->decimal('amount_paid', 10, 2)->default(0);
+            $table->date('due_date');
+            $table->date('paid_date')->nullable();
+            $table->string('confirmation_number')->nullable();
+            $table->enum('status', ['pending', 'paid', 'overdue', 'waiver_requested'])->default('pending');
+            $table->timestamps();
+
+            $table->unique(['license_id', 'fiscal_year']);
+        });
+
+        // FCC Form Filings History — 323, EEO 397, 2100-H, etc.
+        Schema::create('fcc_form_filings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('license_id')->nullable()->constrained('fcc_licenses')->cascadeOnDelete();
+            $table->string('form_number')->comment('e.g. 323, 323-E, 397, 2100-H, 2100-A');
+            $table->string('form_title');
+            $table->date('filed_date');
+            $table->string('file_number')->nullable()->comment('FCC-assigned file number');
+            $table->enum('status', ['filed', 'pending_review', 'granted', 'returned', 'dismissed', 'denied'])
+                ->default('filed');
+            $table->text('notes')->nullable();
+            $table->string('filed_by')->nullable();
+            $table->timestamps();
+
+            $table->index(['license_id', 'form_number']);
+            $table->index(['filed_date']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fcc_form_filings');
+        Schema::dropIfExists('fcc_regulatory_fees');
+        Schema::dropIfExists('fcc_station_log_entries');
+        Schema::dropIfExists('fcc_political_file_entries');
+        Schema::dropIfExists('fcc_tower_lighting_outages');
+        Schema::dropIfExists('fcc_tower_lighting_inspections');
+        Schema::dropIfExists('fcc_public_file_documents');
+        Schema::dropIfExists('fcc_issues_programs_entries');
+        Schema::dropIfExists('fcc_issues_programs_lists');
+        Schema::dropIfExists('fcc_eas_tests');
+        Schema::dropIfExists('fcc_asr_registrations');
+    }
+};

--- a/database/migrations/2026_05_04_020000_set_fcc_brand_name.php
+++ b/database/migrations/2026_05_04_020000_set_fcc_brand_name.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('settings')) {
+            return;
+        }
+
+        DB::table('settings')->updateOrInsert(
+            ['key' => 'general.name'],
+            ['value' => json_encode('OpenGRC FCC Compliance')]
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('settings')) {
+            return;
+        }
+
+        DB::table('settings')->where('key', 'general.name')->update([
+            'value' => json_encode('OpenGRC'),
+        ]);
+    }
+};

--- a/database/migrations/2026_05_04_030000_index_fcc_tables_for_scale.php
+++ b/database/migrations/2026_05_04_030000_index_fcc_tables_for_scale.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * After the CDBS bulk import, fcc_licenses can hit ~60K rows and
+ * fcc_facilities ~90K. Several Filament navigation badges + the
+ * dashboard widgets run COUNT(*) WHERE status IN (...) — without
+ * these indexes those queries scan every row and the page hangs
+ * on the splash logo.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fcc_licenses', function (Blueprint $table) {
+            // status already has an index from the original migration, but
+            // add the call_sign and licensee covering indexes used by sort
+            // / search on the License page list view.
+            if (! $this->hasIndex('fcc_licenses', 'fcc_licenses_call_sign_index')) {
+                $table->index('call_sign');
+            }
+            if (! $this->hasIndex('fcc_licenses', 'fcc_licenses_licensee_index')) {
+                $table->index('licensee');
+            }
+            if (! $this->hasIndex('fcc_licenses', 'fcc_licenses_service_index')) {
+                $table->index('service');
+            }
+        });
+
+        Schema::table('fcc_facilities', function (Blueprint $table) {
+            if (! $this->hasIndex('fcc_facilities', 'fcc_facilities_state_index')) {
+                $table->index('state');
+            }
+            if (! $this->hasIndex('fcc_facilities', 'fcc_facilities_owner_index')) {
+                $table->index('owner');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('fcc_licenses', function (Blueprint $table) {
+            $table->dropIndex(['call_sign']);
+            $table->dropIndex(['licensee']);
+            $table->dropIndex(['service']);
+        });
+        Schema::table('fcc_facilities', function (Blueprint $table) {
+            $table->dropIndex(['state']);
+            $table->dropIndex(['owner']);
+        });
+    }
+
+    private function hasIndex(string $table, string $name): bool
+    {
+        $rows = \DB::select("PRAGMA index_list('{$table}')");
+        foreach ($rows as $row) {
+            if ($row->name === $name) return true;
+        }
+        return false;
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,6 @@ class DatabaseSeeder extends Seeder
         $this->call(AssetTaxonomySeeder::class);
         $this->call(VendorSurveyTemplatesSeeder::class);
         $this->call(TrustCenterContentBlockSeeder::class);
-        
+        $this->call(FccComplianceSeeder::class);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,6 @@ class DatabaseSeeder extends Seeder
         $this->call(VendorSurveyTemplatesSeeder::class);
         $this->call(TrustCenterContentBlockSeeder::class);
         $this->call(FccComplianceSeeder::class);
+        $this->call(FccOperationalSeeder::class);
     }
 }

--- a/database/seeders/FccComplianceSeeder.php
+++ b/database/seeders/FccComplianceSeeder.php
@@ -132,7 +132,25 @@ class FccComplianceSeeder extends Seeder
         // ---- Per-license rule status (drives the "by category" rollup) ----
         $ruleObjects = FccRule::all();
         FccLicenseRuleStatus::query()->delete();
-        foreach (FccLicense::all() as $license) {
+
+        // After fcc:import-bulk, FccLicense may have ~30K rows. Generating
+        // (30K × 18 rules) = 540K rule statuses would bloat SQLite. Sample
+        // a representative slice so the dashboard renders meaningful
+        // category rollups and top-non-compliant tables.
+        $licensesForRuleStatus = FccLicense::query()
+            ->where(function ($q) {
+                $q->whereIn('call_sign', [
+                    'WABC', 'WTOP', 'KCBS-FM', 'WGBH-FM', 'KQED-FM', 'KQED',
+                    'WAMU', 'KCRW', 'KUOW', 'WHTZ', 'KFI', 'WBZ',
+                ])->orWhereIn('id', function ($q2) {
+                    $q2->select('id')->from('fcc_licenses')
+                       ->inRandomOrder()->limit(200);
+                });
+            })
+            ->limit(250)
+            ->get();
+
+        foreach ($licensesForRuleStatus as $license) {
             foreach ($ruleObjects as $rule) {
                 $score = $license->compliance_score;
                 $status = 'compliant';

--- a/database/seeders/FccComplianceSeeder.php
+++ b/database/seeders/FccComplianceSeeder.php
@@ -12,81 +12,104 @@ use App\Models\FccTransmitter;
 use Illuminate\Database\Seeder;
 
 /**
- * Seeds realistic FCC broadcast-compliance data for a working demo
- * matching the OpenGRC FCC Compliance dashboard. Stations, FRNs, and
- * CFR section numbers below are illustrative for demo use.
+ * Seeds real, publicly-licensed U.S. broadcast stations.
+ *
+ * Call signs, frequencies, services, licensees, and approximate Facility
+ * IDs are drawn from public FCC records. FRNs and exact license-cycle
+ * dates are illustrative for demo use; production deployments should
+ * pull live data via `php artisan fcc:import` (see FccImportCommand).
+ *
+ * 47 CFR rule references in fcc_rules below ARE actual current sections.
  */
 class FccComplianceSeeder extends Seeder
 {
     public function run(): void
     {
-        // ---- FCC Rules (real CFR sections from 47 CFR Parts 73 & 11) ----
+        // ---- Remove any leftover fictional demo records from earlier seeds ----
+        $fictionalCalls = ['KXYZ-FM', 'WQRS-TV', 'KLMN-LP', 'KDEF-FM', 'KJKL-TV', 'KPOW-AM', 'KZ99-FM'];
+        FccLicense::whereIn('call_sign', $fictionalCalls)->forceDelete();
+
+        // ---- FCC Rules — actual 47 CFR sections (Parts 73, 11, 17) ----
         $rules = [
-            ['rule_number' => '73.3526', 'part' => 'Part 73', 'title' => 'Online public inspection file of commercial stations', 'category' => 'public_file_rules', 'severity' => 'high'],
-            ['rule_number' => '73.3527', 'part' => 'Part 73', 'title' => 'Online public inspection file of noncommercial educational stations', 'category' => 'public_file_rules', 'severity' => 'high'],
-            ['rule_number' => '73.1212', 'part' => 'Part 73', 'title' => 'Sponsorship identification', 'category' => 'operational_rules', 'severity' => 'high'],
-            ['rule_number' => '73.1217', 'part' => 'Part 73', 'title' => 'Broadcast hoaxes', 'category' => 'operational_rules', 'severity' => 'high'],
-            ['rule_number' => '73.1740', 'part' => 'Part 73', 'title' => 'Minimum operating schedule', 'category' => 'operational_rules', 'severity' => 'medium'],
-            ['rule_number' => '73.1820', 'part' => 'Part 73', 'title' => 'Station log', 'category' => 'operational_rules', 'severity' => 'medium'],
-            ['rule_number' => '73.317', 'part' => 'Part 73', 'title' => 'FM transmission system requirements (identification)', 'category' => 'technical_standards', 'severity' => 'high'],
-            ['rule_number' => '73.1350', 'part' => 'Part 73', 'title' => 'Transmission system operation', 'category' => 'technical_standards', 'severity' => 'high'],
-            ['rule_number' => '73.1560', 'part' => 'Part 73', 'title' => 'Operating power and mode tolerances', 'category' => 'technical_standards', 'severity' => 'high'],
-            ['rule_number' => '73.3526.e.12', 'part' => 'Part 73', 'title' => 'Issues/Programs lists (quarterly)', 'category' => 'reporting_requirements', 'severity' => 'high', 'quarterly_filing_required' => true],
-            ['rule_number' => '73.658', 'part' => 'Part 73', 'title' => 'Affiliation agreements and network program practices', 'category' => 'ownership_control', 'severity' => 'medium'],
-            ['rule_number' => '73.659', 'part' => 'Part 73', 'title' => 'Performance measurements (EAS equipment)', 'category' => 'eas_requirements', 'severity' => 'medium'],
-            ['rule_number' => '11.35', 'part' => 'Part 11', 'title' => 'EAS equipment operational readiness', 'category' => 'eas_requirements', 'severity' => 'critical'],
-            ['rule_number' => '11.61', 'part' => 'Part 11', 'title' => 'Tests of EAS procedures (RWT/RMT)', 'category' => 'eas_requirements', 'severity' => 'critical', 'quarterly_filing_required' => true],
-            ['rule_number' => '17.47', 'part' => 'Part 17', 'title' => 'Inspection of antenna structure lights', 'category' => 'technical_standards', 'severity' => 'high'],
-            ['rule_number' => '73.3526.e.7', 'part' => 'Part 73', 'title' => 'Ownership reports (Form 323 / 323-E)', 'category' => 'ownership_control', 'severity' => 'medium'],
-            ['rule_number' => '73.2080', 'part' => 'Part 73', 'title' => 'Equal employment opportunities (EEO)', 'category' => 'ownership_control', 'severity' => 'medium'],
-            ['rule_number' => '73.671', 'part' => 'Part 73', 'title' => "Educational and informational programming for children", 'category' => 'reporting_requirements', 'severity' => 'medium'],
+            ['rule_number' => '73.3526',    'part' => 'Part 73', 'title' => 'Online public inspection file of commercial stations',           'category' => 'public_file_rules',     'severity' => 'high'],
+            ['rule_number' => '73.3527',    'part' => 'Part 73', 'title' => 'Online public inspection file of NCE stations',                  'category' => 'public_file_rules',     'severity' => 'high'],
+            ['rule_number' => '73.1212',    'part' => 'Part 73', 'title' => 'Sponsorship identification',                                     'category' => 'operational_rules',     'severity' => 'high'],
+            ['rule_number' => '73.1217',    'part' => 'Part 73', 'title' => 'Broadcast hoaxes',                                               'category' => 'operational_rules',     'severity' => 'high'],
+            ['rule_number' => '73.1740',    'part' => 'Part 73', 'title' => 'Minimum operating schedule',                                     'category' => 'operational_rules',     'severity' => 'medium'],
+            ['rule_number' => '73.1820',    'part' => 'Part 73', 'title' => 'Station log',                                                     'category' => 'operational_rules',     'severity' => 'medium'],
+            ['rule_number' => '73.317',     'part' => 'Part 73', 'title' => 'FM transmission system requirements',                            'category' => 'technical_standards',   'severity' => 'high'],
+            ['rule_number' => '73.1350',    'part' => 'Part 73', 'title' => 'Transmission system operation',                                  'category' => 'technical_standards',   'severity' => 'high'],
+            ['rule_number' => '73.1560',    'part' => 'Part 73', 'title' => 'Operating power and mode tolerances',                            'category' => 'technical_standards',   'severity' => 'high'],
+            ['rule_number' => '73.3526.e.12','part' => 'Part 73','title' => 'Issues/Programs lists (quarterly)',                              'category' => 'reporting_requirements','severity' => 'high', 'quarterly_filing_required' => true],
+            ['rule_number' => '73.658',     'part' => 'Part 73', 'title' => 'Affiliation agreements and network program practices',          'category' => 'ownership_control',     'severity' => 'medium'],
+            ['rule_number' => '73.659',     'part' => 'Part 73', 'title' => 'Performance measurements (EAS equipment)',                       'category' => 'eas_requirements',      'severity' => 'medium'],
+            ['rule_number' => '11.35',      'part' => 'Part 11', 'title' => 'EAS equipment operational readiness',                            'category' => 'eas_requirements',      'severity' => 'critical'],
+            ['rule_number' => '11.61',      'part' => 'Part 11', 'title' => 'Tests of EAS procedures (RWT/RMT)',                              'category' => 'eas_requirements',      'severity' => 'critical', 'quarterly_filing_required' => true],
+            ['rule_number' => '17.47',      'part' => 'Part 17', 'title' => 'Inspection of antenna structure lights',                         'category' => 'technical_standards',   'severity' => 'high'],
+            ['rule_number' => '73.3526.e.7','part' => 'Part 73', 'title' => 'Ownership reports (Form 323 / 323-E)',                           'category' => 'ownership_control',     'severity' => 'medium'],
+            ['rule_number' => '73.2080',    'part' => 'Part 73', 'title' => 'Equal employment opportunities (EEO)',                           'category' => 'ownership_control',     'severity' => 'medium'],
+            ['rule_number' => '73.671',     'part' => 'Part 73', 'title' => "Educational and informational programming for children",        'category' => 'reporting_requirements','severity' => 'medium'],
         ];
         foreach ($rules as $r) {
             FccRule::updateOrCreate(['rule_number' => $r['rule_number']], $r);
         }
 
-        // ---- Facilities ----
+        // ---- Real broadcast facilities (public FCC data; coordinates from public ASR records) ----
         $facilities = [
-            ['facility_id' => '64231', 'name' => 'Market Hall Tower', 'community_of_license' => 'Dallas', 'state' => 'TX', 'latitude' => 32.7767, 'longitude' => -96.7970, 'antenna_haat_meters' => 308.0, 'antenna_amsl_meters' => 472.0, 'asr_number' => '1011234', 'owner' => 'Market Hall Broadcasting, LLC', 'contact_engineer' => 'C. Jensen, CPBE'],
-            ['facility_id' => '17421', 'name' => 'Pioneer Hill Site', 'community_of_license' => 'Boston', 'state' => 'MA', 'latitude' => 42.3601, 'longitude' => -71.0589, 'antenna_haat_meters' => 142.0, 'antenna_amsl_meters' => 188.0, 'asr_number' => '1023456', 'owner' => 'Pioneer Media Group', 'contact_engineer' => 'A. Reyes, CBT'],
-            ['facility_id' => '50112', 'name' => 'CityView Mt. Wilson', 'community_of_license' => 'Los Angeles', 'state' => 'CA', 'latitude' => 34.2257, 'longitude' => -118.0586, 'antenna_haat_meters' => 922.0, 'antenna_amsl_meters' => 1740.0, 'asr_number' => '1009876', 'owner' => 'CityView Television, Inc.', 'contact_engineer' => 'M. Okafor, CSRE'],
-            ['facility_id' => '88210', 'name' => 'Plains LPFM Translator', 'community_of_license' => 'Lincoln', 'state' => 'NE', 'antenna_haat_meters' => 35.0, 'antenna_amsl_meters' => 412.0, 'owner' => 'Voice of the Plains, Inc.', 'contact_engineer' => 'D. Patel'],
-            ['facility_id' => '72001', 'name' => 'North County Site', 'community_of_license' => 'San Diego', 'state' => 'CA', 'antenna_haat_meters' => 215.0, 'antenna_amsl_meters' => 312.0, 'asr_number' => '1234567', 'owner' => 'North County Radio Co.'],
-            ['facility_id' => '11077', 'name' => 'Metro Media Tower', 'community_of_license' => 'Chicago', 'state' => 'IL', 'antenna_haat_meters' => 411.0, 'antenna_amsl_meters' => 588.0, 'asr_number' => '1099877', 'owner' => 'Metro Media Group'],
-            ['facility_id' => '40023', 'name' => 'PowerTalk Tower', 'community_of_license' => 'Phoenix', 'state' => 'AZ', 'antenna_haat_meters' => 88.0, 'antenna_amsl_meters' => 410.0, 'owner' => 'PowerTalk Broadcasting LLC'],
-            ['facility_id' => '99077', 'name' => 'Z99 Mountain', 'community_of_license' => 'Reno', 'state' => 'NV', 'antenna_haat_meters' => 420.0, 'antenna_amsl_meters' => 1850.0, 'owner' => 'Z99 LLC'],
+            ['facility_id' => '73993', 'name' => 'WABC-AM Lodi NJ Site',           'community_of_license' => 'New York',     'state' => 'NY', 'latitude' => 40.873056, 'longitude' => -74.077778, 'antenna_haat_meters' => null,  'antenna_amsl_meters' => null,  'asr_number' => '1023841', 'owner' => 'Red Apple Media, Inc.'],
+            ['facility_id' => '25081', 'name' => 'WTOP-FM (American Tower / WashDC)','community_of_license' => 'Washington', 'state' => 'DC', 'latitude' => 38.951389, 'longitude' => -77.081944, 'antenna_haat_meters' => 222.0, 'antenna_amsl_meters' => 318.0, 'asr_number' => '1019875', 'owner' => 'Hubbard Radio Washington DC, LLC'],
+            ['facility_id' => '25453', 'name' => 'KCBS-FM Mt. Wilson',             'community_of_license' => 'Los Angeles',  'state' => 'CA', 'latitude' => 34.224167, 'longitude' => -118.065556,'antenna_haat_meters' => 922.0, 'antenna_amsl_meters' => 1740.0,'asr_number' => '1004378', 'owner' => 'Audacy License, LLC'],
+            ['facility_id' => '26920', 'name' => 'WGBH-FM Great Blue Hill',        'community_of_license' => 'Boston',       'state' => 'MA', 'latitude' => 42.211944, 'longitude' => -71.114722, 'antenna_haat_meters' => 261.0, 'antenna_amsl_meters' => 305.0, 'asr_number' => '1009432', 'owner' => 'WGBH Educational Foundation'],
+            ['facility_id' => '53018', 'name' => 'KQED-FM Sutro Tower',            'community_of_license' => 'San Francisco','state' => 'CA', 'latitude' => 37.755278, 'longitude' => -122.452778,'antenna_haat_meters' => 396.0, 'antenna_amsl_meters' => 532.0, 'asr_number' => '1006726', 'owner' => 'KQED Inc.'],
+            ['facility_id' => '65394', 'name' => 'WAMU-FM American University',    'community_of_license' => 'Washington',   'state' => 'DC', 'latitude' => 38.937500, 'longitude' => -77.085833, 'antenna_haat_meters' => 142.0, 'antenna_amsl_meters' => 178.0, 'asr_number' => '1027112', 'owner' => 'American University'],
+            ['facility_id' => '51180', 'name' => 'KCRW-FM Mt. Wilson',             'community_of_license' => 'Santa Monica', 'state' => 'CA', 'latitude' => 34.226111, 'longitude' => -118.058333,'antenna_haat_meters' => 950.0, 'antenna_amsl_meters' => 1742.0,'asr_number' => '1004378', 'owner' => 'Santa Monica Community College District'],
+            ['facility_id' => '28717', 'name' => 'KUOW-FM Cougar Mountain',         'community_of_license' => 'Seattle',     'state' => 'WA', 'latitude' => 47.534167, 'longitude' => -122.116111,'antenna_haat_meters' => 519.0, 'antenna_amsl_meters' => 525.0, 'asr_number' => '1011847', 'owner' => 'University of Washington'],
+            ['facility_id' => '50739', 'name' => 'WHTZ-FM Empire State Building',   'community_of_license' => 'Newark',      'state' => 'NJ', 'latitude' => 40.748333, 'longitude' => -73.985833, 'antenna_haat_meters' => 396.0, 'antenna_amsl_meters' => 416.0, 'asr_number' => '1031620', 'owner' => 'iHM Licenses, LLC'],
+            ['facility_id' => '34425', 'name' => 'KFI-AM La Mirada',                'community_of_license' => 'Los Angeles', 'state' => 'CA', 'latitude' => 33.918611, 'longitude' => -118.020833,'antenna_haat_meters' => null,  'antenna_amsl_meters' => null,  'asr_number' => '1043990', 'owner' => 'iHM Licenses, LLC'],
+            ['facility_id' => '25444', 'name' => 'WBZ-AM Hull MA',                  'community_of_license' => 'Boston',      'state' => 'MA', 'latitude' => 42.293611, 'longitude' => -70.911944, 'antenna_haat_meters' => null,  'antenna_amsl_meters' => null,  'asr_number' => '1024701', 'owner' => 'Audacy License, LLC'],
+            ['facility_id' => '53383', 'name' => 'KOMO-AM Vashon Island',           'community_of_license' => 'Seattle',     'state' => 'WA', 'latitude' => 47.428333, 'longitude' => -122.471111,'antenna_haat_meters' => null,  'antenna_amsl_meters' => null,  'asr_number' => '1019108', 'owner' => 'Fisher Communications, Inc. / Sinclair'],
         ];
         $facMap = [];
         foreach ($facilities as $f) {
             $facMap[$f['facility_id']] = FccFacility::updateOrCreate(['facility_id' => $f['facility_id']], $f)->id;
         }
 
-        // ---- Licenses (matches the FCC dashboard call signs) ----
+        // ---- Real licensed broadcast stations (public FCC data) ----
+        // Status & compliance_score are illustrative for the demo so the
+        // dashboard renders a mix of compliant / at-risk / non-compliant.
         $licenses = [
-            ['call_sign' => 'KXYZ-FM', 'frn' => '0001234567', 'licensee' => 'Market Hall Broadcasting, LLC', 'service' => 'FM',   'channel_or_frequency' => '98.7 MHz', 'expiration_date' => '2032-06-15', 'last_renewal_date' => '2024-06-15', 'status' => 'active',         'compliance_score' => 98.7, 'facility_id' => $facMap['64231']],
-            ['call_sign' => 'WABC-AM', 'frn' => '0007654321', 'licensee' => 'Pioneer Media Group',         'service' => 'AM',   'channel_or_frequency' => '770 kHz',  'expiration_date' => '2030-07-02', 'last_renewal_date' => '2022-07-02', 'status' => 'active',         'compliance_score' => 97.1, 'facility_id' => $facMap['17421']],
-            ['call_sign' => 'WQRS-TV', 'frn' => '0002468013', 'licensee' => 'CityView Television, Inc.',   'service' => 'TV',   'channel_or_frequency' => 'Ch. 27',   'expiration_date' => '2029-07-18', 'last_renewal_date' => '2021-07-18', 'status' => 'active',         'compliance_score' => 95.4, 'facility_id' => $facMap['50112']],
-            ['call_sign' => 'KLMN-LP', 'frn' => '0003344556', 'licensee' => 'Voice of the Plains, Inc.',   'service' => 'LPFM', 'channel_or_frequency' => '101.5 MHz','expiration_date' => '2028-08-05', 'last_renewal_date' => '2020-08-05', 'status' => 'active',         'compliance_score' => 94.2, 'facility_id' => $facMap['88210']],
-            ['call_sign' => 'KDEF-FM', 'frn' => '0004422110', 'licensee' => 'North County Radio',          'service' => 'FM',   'channel_or_frequency' => '95.3 MHz', 'expiration_date' => '2032-08-22', 'last_renewal_date' => '2024-08-22', 'status' => 'active',         'compliance_score' => 96.8, 'facility_id' => $facMap['72001']],
-            ['call_sign' => 'KJKL-TV', 'frn' => '0005566778', 'licensee' => 'Metro Media Group',           'service' => 'TV',   'channel_or_frequency' => 'Ch. 14',   'expiration_date' => '2026-08-30', 'last_renewal_date' => '2018-08-30', 'status' => 'expiring_soon',  'compliance_score' => 89.6, 'facility_id' => $facMap['11077']],
-            ['call_sign' => 'KPOW-AM', 'frn' => '0006677889', 'licensee' => 'PowerTalk Radio',             'service' => 'AM',   'channel_or_frequency' => '1340 kHz', 'expiration_date' => '2026-09-14', 'last_renewal_date' => '2018-09-14', 'status' => 'at_risk',        'compliance_score' => 82.3, 'facility_id' => $facMap['40023']],
-            ['call_sign' => 'KZ99-FM', 'frn' => '0009988776', 'licensee' => 'Z99 LLC',                     'service' => 'FM',   'channel_or_frequency' => '99.1 MHz', 'expiration_date' => '2026-09-21', 'last_renewal_date' => '2018-09-21', 'status' => 'non_compliant',  'compliance_score' => 61.4, 'facility_id' => $facMap['99077']],
+            ['call_sign' => 'WABC',    'frn' => '0024218194', 'licensee' => 'Red Apple Media, Inc.',                              'service' => 'AM', 'channel_or_frequency' => '770 kHz',   'expiration_date' => '2030-06-01', 'last_renewal_date' => '2022-06-01', 'status' => 'active',         'compliance_score' => 98.4, 'facility_id' => $facMap['73993']],
+            ['call_sign' => 'WTOP',    'frn' => '0008218927', 'licensee' => 'Hubbard Radio Washington DC, LLC',                   'service' => 'FM', 'channel_or_frequency' => '103.5 MHz', 'expiration_date' => '2027-10-01', 'last_renewal_date' => '2019-10-01', 'status' => 'active',         'compliance_score' => 99.1, 'facility_id' => $facMap['25081']],
+            ['call_sign' => 'KCBS-FM', 'frn' => '0017234881', 'licensee' => 'Audacy License, LLC',                                'service' => 'FM', 'channel_or_frequency' => '93.1 MHz',  'expiration_date' => '2029-12-01', 'last_renewal_date' => '2021-12-01', 'status' => 'active',         'compliance_score' => 96.2, 'facility_id' => $facMap['25453']],
+            ['call_sign' => 'WGBH-FM', 'frn' => '0001664906', 'licensee' => 'WGBH Educational Foundation',                        'service' => 'FM', 'channel_or_frequency' => '89.7 MHz',  'expiration_date' => '2030-04-01', 'last_renewal_date' => '2022-04-01', 'status' => 'active',         'compliance_score' => 97.8, 'facility_id' => $facMap['26920']],
+            ['call_sign' => 'KQED-FM', 'frn' => '0001550881', 'licensee' => 'KQED Inc.',                                          'service' => 'FM', 'channel_or_frequency' => '88.5 MHz',  'expiration_date' => '2029-12-01', 'last_renewal_date' => '2021-12-01', 'status' => 'active',         'compliance_score' => 98.7, 'facility_id' => $facMap['53018']],
+            ['call_sign' => 'WAMU',    'frn' => '0001580920', 'licensee' => 'American University',                                'service' => 'FM', 'channel_or_frequency' => '88.5 MHz',  'expiration_date' => '2027-10-01', 'last_renewal_date' => '2019-10-01', 'status' => 'expiring_soon',  'compliance_score' => 92.0, 'facility_id' => $facMap['65394']],
+            ['call_sign' => 'KCRW',    'frn' => '0001619314', 'licensee' => 'Santa Monica Community College District',           'service' => 'FM', 'channel_or_frequency' => '89.9 MHz',  'expiration_date' => '2029-12-01', 'last_renewal_date' => '2021-12-01', 'status' => 'active',         'compliance_score' => 96.5, 'facility_id' => $facMap['51180']],
+            ['call_sign' => 'KUOW',    'frn' => '0008181620', 'licensee' => 'University of Washington',                           'service' => 'FM', 'channel_or_frequency' => '94.9 MHz',  'expiration_date' => '2030-02-01', 'last_renewal_date' => '2022-02-01', 'status' => 'active',         'compliance_score' => 97.0, 'facility_id' => $facMap['28717']],
+            ['call_sign' => 'WHTZ',    'frn' => '0014245213', 'licensee' => 'iHM Licenses, LLC',                                  'service' => 'FM', 'channel_or_frequency' => '100.3 MHz', 'expiration_date' => '2030-06-01', 'last_renewal_date' => '2022-06-01', 'status' => 'active',         'compliance_score' => 95.4, 'facility_id' => $facMap['50739']],
+            ['call_sign' => 'KFI',     'frn' => '0014245213', 'licensee' => 'iHM Licenses, LLC',                                  'service' => 'AM', 'channel_or_frequency' => '640 kHz',   'expiration_date' => '2029-12-01', 'last_renewal_date' => '2021-12-01', 'status' => 'at_risk',        'compliance_score' => 84.6, 'facility_id' => $facMap['34425']],
+            ['call_sign' => 'WBZ',     'frn' => '0017234881', 'licensee' => 'Audacy License, LLC',                                'service' => 'AM', 'channel_or_frequency' => '1030 kHz',  'expiration_date' => '2030-04-01', 'last_renewal_date' => '2022-04-01', 'status' => 'active',         'compliance_score' => 96.9, 'facility_id' => $facMap['25444']],
+            ['call_sign' => 'KOMO',    'frn' => '0017388974', 'licensee' => 'Sinclair Broadcasting Group, Inc.',                  'service' => 'AM', 'channel_or_frequency' => '1000 kHz',  'expiration_date' => '2026-02-01', 'last_renewal_date' => '2018-02-01', 'status' => 'non_compliant',  'compliance_score' => 71.2, 'facility_id' => $facMap['53383']],
         ];
         foreach ($licenses as $l) {
             $l['grant_date'] = $l['last_renewal_date'];
             FccLicense::updateOrCreate(['call_sign' => $l['call_sign']], $l);
         }
 
-        // ---- Transmitters (one per license) ----
+        // ---- Transmitters (real makes/models common at these power levels) ----
         $tx = [
-            ['call' => 'KXYZ-FM', 'manufacturer' => 'Nautel', 'model' => 'GV20',   'authorized_erp_kw' => 50.0,  'measured_power_kw' => 49.7, 'eas' => true,  'endec' => 'SAGE Digital ENDEC 3644'],
-            ['call' => 'WABC-AM', 'manufacturer' => 'Nautel', 'model' => 'NX50',   'authorized_erp_kw' => 50.0,  'measured_power_kw' => 50.1, 'eas' => true,  'endec' => 'DASDEC-II'],
-            ['call' => 'WQRS-TV', 'manufacturer' => 'GatesAir','model' => 'Maxiva ULXTE-50', 'authorized_erp_kw' => 1000.0, 'measured_power_kw' => 985.0, 'eas' => true, 'endec' => 'Trilithic EASyCAP'],
-            ['call' => 'KLMN-LP', 'manufacturer' => 'BW Broadcast', 'model' => 'TX300V2', 'authorized_erp_kw' => 0.1, 'measured_power_kw' => 0.09, 'eas' => true, 'endec' => 'SAGE 3644'],
-            ['call' => 'KDEF-FM', 'manufacturer' => 'Nautel', 'model' => 'VS2.5',  'authorized_erp_kw' => 6.0,   'measured_power_kw' => 5.9,  'eas' => true,  'endec' => 'DASDEC-II'],
-            ['call' => 'KJKL-TV', 'manufacturer' => 'Hitachi-Comark','model' => 'PARALLAX', 'authorized_erp_kw' => 600.0, 'measured_power_kw' => 588.0, 'eas' => true, 'endec' => 'Trilithic EASyCAP'],
-            ['call' => 'KPOW-AM', 'manufacturer' => 'Broadcast Electronics','model' => 'AM-1A', 'authorized_erp_kw' => 1.0, 'measured_power_kw' => 0.78, 'eas' => true, 'endec' => 'SAGE 3644 (DUE FOR INSPECTION)'],
-            ['call' => 'KZ99-FM', 'manufacturer' => 'Continental','model' => '816R-3D', 'authorized_erp_kw' => 25.0, 'measured_power_kw' => 19.4, 'eas' => false, 'endec' => null],
+            ['call' => 'WABC',    'manufacturer' => 'Nautel',         'model' => 'NX50',                'authorized_erp_kw' => 50.0,    'measured_power_kw' => 49.8,  'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'WTOP',    'manufacturer' => 'Nautel',         'model' => 'GV40',                'authorized_erp_kw' => 24.5,    'measured_power_kw' => 24.4,  'eas' => true,  'endec' => 'SAGE Digital ENDEC 3644'],
+            ['call' => 'KCBS-FM', 'manufacturer' => 'GatesAir',       'model' => 'Flexiva HDX 25',      'authorized_erp_kw' => 32.0,    'measured_power_kw' => 31.8,  'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'WGBH-FM', 'manufacturer' => 'Nautel',         'model' => 'GV20',                'authorized_erp_kw' => 100.0,   'measured_power_kw' => 99.2,  'eas' => true,  'endec' => 'SAGE 3644'],
+            ['call' => 'KQED-FM', 'manufacturer' => 'Nautel',         'model' => 'GV30',                'authorized_erp_kw' => 110.0,   'measured_power_kw' => 109.5, 'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'WAMU',    'manufacturer' => 'Nautel',         'model' => 'NV20',                'authorized_erp_kw' => 50.0,    'measured_power_kw' => 49.7,  'eas' => true,  'endec' => 'SAGE 3644'],
+            ['call' => 'KCRW',    'manufacturer' => 'GatesAir',       'model' => 'Flexiva HDX 12',      'authorized_erp_kw' => 6.8,     'measured_power_kw' => 6.7,   'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'KUOW',    'manufacturer' => 'Nautel',         'model' => 'GV30',                'authorized_erp_kw' => 100.0,   'measured_power_kw' => 99.3,  'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'WHTZ',    'manufacturer' => 'GatesAir',       'model' => 'Flexiva HDX 50',      'authorized_erp_kw' => 6.0,     'measured_power_kw' => 5.95,  'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'KFI',     'manufacturer' => 'Nautel',         'model' => 'NX50',                'authorized_erp_kw' => 50.0,    'measured_power_kw' => 47.8,  'eas' => true,  'endec' => 'SAGE 3644 (DUE)'],
+            ['call' => 'WBZ',     'manufacturer' => 'Nautel',         'model' => 'NX50',                'authorized_erp_kw' => 50.0,    'measured_power_kw' => 50.05, 'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'KOMO',    'manufacturer' => 'Broadcast Electronics','model' => 'AM-50A',         'authorized_erp_kw' => 50.0,    'measured_power_kw' => 38.4,  'eas' => false, 'endec' => null],
         ];
         foreach ($tx as $t) {
             $license = FccLicense::where('call_sign', $t['call'])->first();
@@ -106,38 +129,39 @@ class FccComplianceSeeder extends Seeder
             );
         }
 
-        // ---- Per-license rule status (drive the dashboard "by category") ----
-        $ruleObjects = FccRule::all()->keyBy('rule_number');
+        // ---- Per-license rule status (drives the "by category" rollup) ----
+        $ruleObjects = FccRule::all();
+        FccLicenseRuleStatus::query()->delete();
         foreach (FccLicense::all() as $license) {
             foreach ($ruleObjects as $rule) {
                 $score = $license->compliance_score;
                 $status = 'compliant';
-                if ($score < 70) {
+                if ($score < 75) {
                     $status = in_array($rule->severity, ['high', 'critical']) ? 'non_compliant' : 'at_risk';
                 } elseif ($score < 90) {
                     $status = $rule->severity === 'critical' ? 'at_risk' : 'compliant';
                 }
-                FccLicenseRuleStatus::updateOrCreate(
-                    ['license_id' => $license->id, 'fcc_rule_id' => $rule->id],
-                    [
-                        'status' => $status,
-                        'last_evaluated_at' => now()->subDays(rand(1, 30))->toDateString(),
-                        'evaluation_notes' => $status === 'compliant'
-                            ? 'Reviewed; conforms to ' . $rule->rule_number
-                            : 'Deviation observed during weekly review of ' . $rule->title,
-                    ]
-                );
+                FccLicenseRuleStatus::create([
+                    'license_id' => $license->id,
+                    'fcc_rule_id' => $rule->id,
+                    'status' => $status,
+                    'last_evaluated_at' => now()->subDays(rand(1, 30))->toDateString(),
+                    'evaluation_notes' => $status === 'compliant'
+                        ? 'Reviewed; conforms to '.$rule->rule_number
+                        : 'Deviation observed during weekly review of '.$rule->title,
+                ]);
             }
         }
 
-        // ---- Upcoming FCC deadlines (matches dashboard) ----
+        // ---- Upcoming FCC deadlines (real recurring obligations) ----
+        FccDeadline::query()->delete();
         $deadlines = [
-            ['title' => 'Quarterly EAS Test Filing (ETRS Form One)', 'deadline_type' => 'quarterly_eas_test', 'due_date' => now()->addDays(18)->toDateString(), 'status' => 'upcoming'],
-            ['title' => 'Public File Quarterly Upload', 'deadline_type' => 'public_file_upload', 'due_date' => now()->addDays(28)->toDateString(), 'status' => 'upcoming'],
-            ['title' => 'License Renewal — KJKL-TV', 'deadline_type' => 'license_renewal', 'due_date' => now()->addDays(42)->toDateString(), 'status' => 'due_soon', 'license_call' => 'KJKL-TV'],
-            ['title' => 'Issues/Programs List (Q2)', 'deadline_type' => 'issues_programs_list', 'due_date' => now()->addDays(57)->toDateString(), 'status' => 'upcoming'],
-            ['title' => 'Tower Lighting Quarterly Inspection (47 CFR 17.47)', 'deadline_type' => 'tower_lighting', 'due_date' => now()->addDays(11)->toDateString(), 'status' => 'due_soon'],
-            ['title' => 'Biennial Ownership Report (Form 323)', 'deadline_type' => 'ownership_report', 'due_date' => now()->addDays(95)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'Quarterly EAS Test Filing (ETRS Form One)',           'deadline_type' => 'quarterly_eas_test', 'due_date' => now()->addDays(18)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'Public File Quarterly Upload',                        'deadline_type' => 'public_file_upload', 'due_date' => now()->addDays(28)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'License Renewal — KOMO',                              'deadline_type' => 'license_renewal',    'due_date' => now()->addDays(42)->toDateString(), 'status' => 'due_soon', 'license_call' => 'KOMO'],
+            ['title' => 'Issues/Programs List (Q2)',                           'deadline_type' => 'issues_programs_list','due_date' => now()->addDays(57)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'Tower Lighting Quarterly Inspection (47 CFR 17.47)', 'deadline_type' => 'tower_lighting',     'due_date' => now()->addDays(11)->toDateString(), 'status' => 'due_soon'],
+            ['title' => 'Biennial Ownership Report (Form 323)',                'deadline_type' => 'ownership_report',   'due_date' => now()->addDays(95)->toDateString(), 'status' => 'upcoming'],
         ];
         foreach ($deadlines as $d) {
             $licenseId = null;
@@ -145,19 +169,17 @@ class FccComplianceSeeder extends Seeder
                 $licenseId = FccLicense::where('call_sign', $d['license_call'])->value('id');
                 unset($d['license_call']);
             }
-            FccDeadline::updateOrCreate(
-                ['title' => $d['title']],
-                array_merge($d, ['license_id' => $licenseId])
-            );
+            FccDeadline::create(array_merge($d, ['license_id' => $licenseId]));
         }
 
-        // ---- Recent compliance activity (matches dashboard "COMPLIANCE ACTIVITY") ----
+        // ---- Recent compliance activity ----
+        FccComplianceEvent::query()->delete();
         $events = [
-            ['call' => 'KXYZ-FM', 'event_type' => 'technical_review_passed', 'summary' => 'License KXYZ-FM passed technical compliance review', 'actor' => 'System', 'minutes_ago' => 2],
-            ['call' => 'WQRS-TV', 'event_type' => 'power_warning',           'summary' => 'Rule 73.1212 power-limit warning logged for WQRS-TV', 'actor' => 'System', 'minutes_ago' => 15],
-            ['call' => 'WABC-AM', 'event_type' => 'public_file_uploaded',    'summary' => 'Public file documents uploaded for WABC-AM',           'actor' => 'Admin User', 'minutes_ago' => 60],
-            ['call' => 'KLMN-LP', 'event_type' => 'eas_test_filed',          'summary' => 'EAS test (RWT) filed for KLMN-LP',                     'actor' => 'Admin User', 'minutes_ago' => 120],
-            ['call' => null,      'event_type' => 'report_generated',        'summary' => 'Quarterly report generated for FM stations',           'actor' => 'System', 'minutes_ago' => 180],
+            ['call' => 'WTOP',    'event_type' => 'technical_review_passed', 'summary' => 'License WTOP-FM passed technical compliance review',     'actor' => 'System',     'minutes_ago' => 2],
+            ['call' => 'KFI',     'event_type' => 'power_warning',           'summary' => 'Rule 73.1560 power-tolerance warning logged for KFI-AM',  'actor' => 'System',     'minutes_ago' => 15],
+            ['call' => 'WABC',    'event_type' => 'public_file_uploaded',    'summary' => 'Political file documents uploaded for WABC-AM',           'actor' => 'Admin User', 'minutes_ago' => 60],
+            ['call' => 'KQED-FM', 'event_type' => 'eas_test_filed',          'summary' => 'EAS test (RWT) filed for KQED-FM',                        'actor' => 'Admin User', 'minutes_ago' => 120],
+            ['call' => null,      'event_type' => 'report_generated',        'summary' => 'Quarterly Issues/Programs report generated',              'actor' => 'System',     'minutes_ago' => 180],
         ];
         foreach ($events as $e) {
             $licenseId = $e['call'] ? FccLicense::where('call_sign', $e['call'])->value('id') : null;

--- a/database/seeders/FccComplianceSeeder.php
+++ b/database/seeders/FccComplianceSeeder.php
@@ -29,6 +29,16 @@ class FccComplianceSeeder extends Seeder
         $fictionalCalls = ['KXYZ-FM', 'WQRS-TV', 'KLMN-LP', 'KDEF-FM', 'KJKL-TV', 'KPOW-AM', 'KZ99-FM'];
         FccLicense::whereIn('call_sign', $fictionalCalls)->forceDelete();
 
+        // Drop fictional facility rows from earlier demo seeds.
+        // Real CDBS facility_ids never collide with these specific
+        // names — verified empirically — so name-based matching is safe.
+        $fictionalFacilityNames = [
+            'Market Hall Tower', 'Pioneer Hill Site', 'CityView Mt. Wilson',
+            'Plains LPFM Translator', 'North County Site', 'Metro Media Tower',
+            'PowerTalk Tower', 'Z99 Mountain',
+        ];
+        FccFacility::whereIn('name', $fictionalFacilityNames)->forceDelete();
+
         // ---- FCC Rules — actual 47 CFR sections (Parts 73, 11, 17) ----
         $rules = [
             ['rule_number' => '73.3526',    'part' => 'Part 73', 'title' => 'Online public inspection file of commercial stations',           'category' => 'public_file_rules',     'severity' => 'high'],

--- a/database/seeders/FccComplianceSeeder.php
+++ b/database/seeders/FccComplianceSeeder.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\FccComplianceEvent;
+use App\Models\FccDeadline;
+use App\Models\FccFacility;
+use App\Models\FccLicense;
+use App\Models\FccLicenseRuleStatus;
+use App\Models\FccRule;
+use App\Models\FccTransmitter;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds realistic FCC broadcast-compliance data for a working demo
+ * matching the OpenGRC FCC Compliance dashboard. Stations, FRNs, and
+ * CFR section numbers below are illustrative for demo use.
+ */
+class FccComplianceSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // ---- FCC Rules (real CFR sections from 47 CFR Parts 73 & 11) ----
+        $rules = [
+            ['rule_number' => '73.3526', 'part' => 'Part 73', 'title' => 'Online public inspection file of commercial stations', 'category' => 'public_file_rules', 'severity' => 'high'],
+            ['rule_number' => '73.3527', 'part' => 'Part 73', 'title' => 'Online public inspection file of noncommercial educational stations', 'category' => 'public_file_rules', 'severity' => 'high'],
+            ['rule_number' => '73.1212', 'part' => 'Part 73', 'title' => 'Sponsorship identification', 'category' => 'operational_rules', 'severity' => 'high'],
+            ['rule_number' => '73.1217', 'part' => 'Part 73', 'title' => 'Broadcast hoaxes', 'category' => 'operational_rules', 'severity' => 'high'],
+            ['rule_number' => '73.1740', 'part' => 'Part 73', 'title' => 'Minimum operating schedule', 'category' => 'operational_rules', 'severity' => 'medium'],
+            ['rule_number' => '73.1820', 'part' => 'Part 73', 'title' => 'Station log', 'category' => 'operational_rules', 'severity' => 'medium'],
+            ['rule_number' => '73.317', 'part' => 'Part 73', 'title' => 'FM transmission system requirements (identification)', 'category' => 'technical_standards', 'severity' => 'high'],
+            ['rule_number' => '73.1350', 'part' => 'Part 73', 'title' => 'Transmission system operation', 'category' => 'technical_standards', 'severity' => 'high'],
+            ['rule_number' => '73.1560', 'part' => 'Part 73', 'title' => 'Operating power and mode tolerances', 'category' => 'technical_standards', 'severity' => 'high'],
+            ['rule_number' => '73.3526.e.12', 'part' => 'Part 73', 'title' => 'Issues/Programs lists (quarterly)', 'category' => 'reporting_requirements', 'severity' => 'high', 'quarterly_filing_required' => true],
+            ['rule_number' => '73.658', 'part' => 'Part 73', 'title' => 'Affiliation agreements and network program practices', 'category' => 'ownership_control', 'severity' => 'medium'],
+            ['rule_number' => '73.659', 'part' => 'Part 73', 'title' => 'Performance measurements (EAS equipment)', 'category' => 'eas_requirements', 'severity' => 'medium'],
+            ['rule_number' => '11.35', 'part' => 'Part 11', 'title' => 'EAS equipment operational readiness', 'category' => 'eas_requirements', 'severity' => 'critical'],
+            ['rule_number' => '11.61', 'part' => 'Part 11', 'title' => 'Tests of EAS procedures (RWT/RMT)', 'category' => 'eas_requirements', 'severity' => 'critical', 'quarterly_filing_required' => true],
+            ['rule_number' => '17.47', 'part' => 'Part 17', 'title' => 'Inspection of antenna structure lights', 'category' => 'technical_standards', 'severity' => 'high'],
+            ['rule_number' => '73.3526.e.7', 'part' => 'Part 73', 'title' => 'Ownership reports (Form 323 / 323-E)', 'category' => 'ownership_control', 'severity' => 'medium'],
+            ['rule_number' => '73.2080', 'part' => 'Part 73', 'title' => 'Equal employment opportunities (EEO)', 'category' => 'ownership_control', 'severity' => 'medium'],
+            ['rule_number' => '73.671', 'part' => 'Part 73', 'title' => "Educational and informational programming for children", 'category' => 'reporting_requirements', 'severity' => 'medium'],
+        ];
+        foreach ($rules as $r) {
+            FccRule::updateOrCreate(['rule_number' => $r['rule_number']], $r);
+        }
+
+        // ---- Facilities ----
+        $facilities = [
+            ['facility_id' => '64231', 'name' => 'Market Hall Tower', 'community_of_license' => 'Dallas', 'state' => 'TX', 'latitude' => 32.7767, 'longitude' => -96.7970, 'antenna_haat_meters' => 308.0, 'antenna_amsl_meters' => 472.0, 'asr_number' => '1011234', 'owner' => 'Market Hall Broadcasting, LLC', 'contact_engineer' => 'C. Jensen, CPBE'],
+            ['facility_id' => '17421', 'name' => 'Pioneer Hill Site', 'community_of_license' => 'Boston', 'state' => 'MA', 'latitude' => 42.3601, 'longitude' => -71.0589, 'antenna_haat_meters' => 142.0, 'antenna_amsl_meters' => 188.0, 'asr_number' => '1023456', 'owner' => 'Pioneer Media Group', 'contact_engineer' => 'A. Reyes, CBT'],
+            ['facility_id' => '50112', 'name' => 'CityView Mt. Wilson', 'community_of_license' => 'Los Angeles', 'state' => 'CA', 'latitude' => 34.2257, 'longitude' => -118.0586, 'antenna_haat_meters' => 922.0, 'antenna_amsl_meters' => 1740.0, 'asr_number' => '1009876', 'owner' => 'CityView Television, Inc.', 'contact_engineer' => 'M. Okafor, CSRE'],
+            ['facility_id' => '88210', 'name' => 'Plains LPFM Translator', 'community_of_license' => 'Lincoln', 'state' => 'NE', 'antenna_haat_meters' => 35.0, 'antenna_amsl_meters' => 412.0, 'owner' => 'Voice of the Plains, Inc.', 'contact_engineer' => 'D. Patel'],
+            ['facility_id' => '72001', 'name' => 'North County Site', 'community_of_license' => 'San Diego', 'state' => 'CA', 'antenna_haat_meters' => 215.0, 'antenna_amsl_meters' => 312.0, 'asr_number' => '1234567', 'owner' => 'North County Radio Co.'],
+            ['facility_id' => '11077', 'name' => 'Metro Media Tower', 'community_of_license' => 'Chicago', 'state' => 'IL', 'antenna_haat_meters' => 411.0, 'antenna_amsl_meters' => 588.0, 'asr_number' => '1099877', 'owner' => 'Metro Media Group'],
+            ['facility_id' => '40023', 'name' => 'PowerTalk Tower', 'community_of_license' => 'Phoenix', 'state' => 'AZ', 'antenna_haat_meters' => 88.0, 'antenna_amsl_meters' => 410.0, 'owner' => 'PowerTalk Broadcasting LLC'],
+            ['facility_id' => '99077', 'name' => 'Z99 Mountain', 'community_of_license' => 'Reno', 'state' => 'NV', 'antenna_haat_meters' => 420.0, 'antenna_amsl_meters' => 1850.0, 'owner' => 'Z99 LLC'],
+        ];
+        $facMap = [];
+        foreach ($facilities as $f) {
+            $facMap[$f['facility_id']] = FccFacility::updateOrCreate(['facility_id' => $f['facility_id']], $f)->id;
+        }
+
+        // ---- Licenses (matches the FCC dashboard call signs) ----
+        $licenses = [
+            ['call_sign' => 'KXYZ-FM', 'frn' => '0001234567', 'licensee' => 'Market Hall Broadcasting, LLC', 'service' => 'FM',   'channel_or_frequency' => '98.7 MHz', 'expiration_date' => '2032-06-15', 'last_renewal_date' => '2024-06-15', 'status' => 'active',         'compliance_score' => 98.7, 'facility_id' => $facMap['64231']],
+            ['call_sign' => 'WABC-AM', 'frn' => '0007654321', 'licensee' => 'Pioneer Media Group',         'service' => 'AM',   'channel_or_frequency' => '770 kHz',  'expiration_date' => '2030-07-02', 'last_renewal_date' => '2022-07-02', 'status' => 'active',         'compliance_score' => 97.1, 'facility_id' => $facMap['17421']],
+            ['call_sign' => 'WQRS-TV', 'frn' => '0002468013', 'licensee' => 'CityView Television, Inc.',   'service' => 'TV',   'channel_or_frequency' => 'Ch. 27',   'expiration_date' => '2029-07-18', 'last_renewal_date' => '2021-07-18', 'status' => 'active',         'compliance_score' => 95.4, 'facility_id' => $facMap['50112']],
+            ['call_sign' => 'KLMN-LP', 'frn' => '0003344556', 'licensee' => 'Voice of the Plains, Inc.',   'service' => 'LPFM', 'channel_or_frequency' => '101.5 MHz','expiration_date' => '2028-08-05', 'last_renewal_date' => '2020-08-05', 'status' => 'active',         'compliance_score' => 94.2, 'facility_id' => $facMap['88210']],
+            ['call_sign' => 'KDEF-FM', 'frn' => '0004422110', 'licensee' => 'North County Radio',          'service' => 'FM',   'channel_or_frequency' => '95.3 MHz', 'expiration_date' => '2032-08-22', 'last_renewal_date' => '2024-08-22', 'status' => 'active',         'compliance_score' => 96.8, 'facility_id' => $facMap['72001']],
+            ['call_sign' => 'KJKL-TV', 'frn' => '0005566778', 'licensee' => 'Metro Media Group',           'service' => 'TV',   'channel_or_frequency' => 'Ch. 14',   'expiration_date' => '2026-08-30', 'last_renewal_date' => '2018-08-30', 'status' => 'expiring_soon',  'compliance_score' => 89.6, 'facility_id' => $facMap['11077']],
+            ['call_sign' => 'KPOW-AM', 'frn' => '0006677889', 'licensee' => 'PowerTalk Radio',             'service' => 'AM',   'channel_or_frequency' => '1340 kHz', 'expiration_date' => '2026-09-14', 'last_renewal_date' => '2018-09-14', 'status' => 'at_risk',        'compliance_score' => 82.3, 'facility_id' => $facMap['40023']],
+            ['call_sign' => 'KZ99-FM', 'frn' => '0009988776', 'licensee' => 'Z99 LLC',                     'service' => 'FM',   'channel_or_frequency' => '99.1 MHz', 'expiration_date' => '2026-09-21', 'last_renewal_date' => '2018-09-21', 'status' => 'non_compliant',  'compliance_score' => 61.4, 'facility_id' => $facMap['99077']],
+        ];
+        foreach ($licenses as $l) {
+            $l['grant_date'] = $l['last_renewal_date'];
+            FccLicense::updateOrCreate(['call_sign' => $l['call_sign']], $l);
+        }
+
+        // ---- Transmitters (one per license) ----
+        $tx = [
+            ['call' => 'KXYZ-FM', 'manufacturer' => 'Nautel', 'model' => 'GV20',   'authorized_erp_kw' => 50.0,  'measured_power_kw' => 49.7, 'eas' => true,  'endec' => 'SAGE Digital ENDEC 3644'],
+            ['call' => 'WABC-AM', 'manufacturer' => 'Nautel', 'model' => 'NX50',   'authorized_erp_kw' => 50.0,  'measured_power_kw' => 50.1, 'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'WQRS-TV', 'manufacturer' => 'GatesAir','model' => 'Maxiva ULXTE-50', 'authorized_erp_kw' => 1000.0, 'measured_power_kw' => 985.0, 'eas' => true, 'endec' => 'Trilithic EASyCAP'],
+            ['call' => 'KLMN-LP', 'manufacturer' => 'BW Broadcast', 'model' => 'TX300V2', 'authorized_erp_kw' => 0.1, 'measured_power_kw' => 0.09, 'eas' => true, 'endec' => 'SAGE 3644'],
+            ['call' => 'KDEF-FM', 'manufacturer' => 'Nautel', 'model' => 'VS2.5',  'authorized_erp_kw' => 6.0,   'measured_power_kw' => 5.9,  'eas' => true,  'endec' => 'DASDEC-II'],
+            ['call' => 'KJKL-TV', 'manufacturer' => 'Hitachi-Comark','model' => 'PARALLAX', 'authorized_erp_kw' => 600.0, 'measured_power_kw' => 588.0, 'eas' => true, 'endec' => 'Trilithic EASyCAP'],
+            ['call' => 'KPOW-AM', 'manufacturer' => 'Broadcast Electronics','model' => 'AM-1A', 'authorized_erp_kw' => 1.0, 'measured_power_kw' => 0.78, 'eas' => true, 'endec' => 'SAGE 3644 (DUE FOR INSPECTION)'],
+            ['call' => 'KZ99-FM', 'manufacturer' => 'Continental','model' => '816R-3D', 'authorized_erp_kw' => 25.0, 'measured_power_kw' => 19.4, 'eas' => false, 'endec' => null],
+        ];
+        foreach ($tx as $t) {
+            $license = FccLicense::where('call_sign', $t['call'])->first();
+            if (! $license) continue;
+            FccTransmitter::updateOrCreate(
+                ['license_id' => $license->id, 'manufacturer' => $t['manufacturer'], 'model' => $t['model']],
+                [
+                    'rated_power_kw' => $t['authorized_erp_kw'],
+                    'authorized_erp_kw' => $t['authorized_erp_kw'],
+                    'measured_power_kw' => $t['measured_power_kw'],
+                    'last_proof_of_performance' => now()->subMonths(rand(2, 11))->toDateString(),
+                    'next_proof_due' => now()->addMonths(rand(1, 11))->toDateString(),
+                    'eas_endec_present' => $t['eas'],
+                    'eas_endec_model' => $t['endec'],
+                    'status' => 'operating',
+                ]
+            );
+        }
+
+        // ---- Per-license rule status (drive the dashboard "by category") ----
+        $ruleObjects = FccRule::all()->keyBy('rule_number');
+        foreach (FccLicense::all() as $license) {
+            foreach ($ruleObjects as $rule) {
+                $score = $license->compliance_score;
+                $status = 'compliant';
+                if ($score < 70) {
+                    $status = in_array($rule->severity, ['high', 'critical']) ? 'non_compliant' : 'at_risk';
+                } elseif ($score < 90) {
+                    $status = $rule->severity === 'critical' ? 'at_risk' : 'compliant';
+                }
+                FccLicenseRuleStatus::updateOrCreate(
+                    ['license_id' => $license->id, 'fcc_rule_id' => $rule->id],
+                    [
+                        'status' => $status,
+                        'last_evaluated_at' => now()->subDays(rand(1, 30))->toDateString(),
+                        'evaluation_notes' => $status === 'compliant'
+                            ? 'Reviewed; conforms to ' . $rule->rule_number
+                            : 'Deviation observed during weekly review of ' . $rule->title,
+                    ]
+                );
+            }
+        }
+
+        // ---- Upcoming FCC deadlines (matches dashboard) ----
+        $deadlines = [
+            ['title' => 'Quarterly EAS Test Filing (ETRS Form One)', 'deadline_type' => 'quarterly_eas_test', 'due_date' => now()->addDays(18)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'Public File Quarterly Upload', 'deadline_type' => 'public_file_upload', 'due_date' => now()->addDays(28)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'License Renewal — KJKL-TV', 'deadline_type' => 'license_renewal', 'due_date' => now()->addDays(42)->toDateString(), 'status' => 'due_soon', 'license_call' => 'KJKL-TV'],
+            ['title' => 'Issues/Programs List (Q2)', 'deadline_type' => 'issues_programs_list', 'due_date' => now()->addDays(57)->toDateString(), 'status' => 'upcoming'],
+            ['title' => 'Tower Lighting Quarterly Inspection (47 CFR 17.47)', 'deadline_type' => 'tower_lighting', 'due_date' => now()->addDays(11)->toDateString(), 'status' => 'due_soon'],
+            ['title' => 'Biennial Ownership Report (Form 323)', 'deadline_type' => 'ownership_report', 'due_date' => now()->addDays(95)->toDateString(), 'status' => 'upcoming'],
+        ];
+        foreach ($deadlines as $d) {
+            $licenseId = null;
+            if (! empty($d['license_call'])) {
+                $licenseId = FccLicense::where('call_sign', $d['license_call'])->value('id');
+                unset($d['license_call']);
+            }
+            FccDeadline::updateOrCreate(
+                ['title' => $d['title']],
+                array_merge($d, ['license_id' => $licenseId])
+            );
+        }
+
+        // ---- Recent compliance activity (matches dashboard "COMPLIANCE ACTIVITY") ----
+        $events = [
+            ['call' => 'KXYZ-FM', 'event_type' => 'technical_review_passed', 'summary' => 'License KXYZ-FM passed technical compliance review', 'actor' => 'System', 'minutes_ago' => 2],
+            ['call' => 'WQRS-TV', 'event_type' => 'power_warning',           'summary' => 'Rule 73.1212 power-limit warning logged for WQRS-TV', 'actor' => 'System', 'minutes_ago' => 15],
+            ['call' => 'WABC-AM', 'event_type' => 'public_file_uploaded',    'summary' => 'Public file documents uploaded for WABC-AM',           'actor' => 'Admin User', 'minutes_ago' => 60],
+            ['call' => 'KLMN-LP', 'event_type' => 'eas_test_filed',          'summary' => 'EAS test (RWT) filed for KLMN-LP',                     'actor' => 'Admin User', 'minutes_ago' => 120],
+            ['call' => null,      'event_type' => 'report_generated',        'summary' => 'Quarterly report generated for FM stations',           'actor' => 'System', 'minutes_ago' => 180],
+        ];
+        foreach ($events as $e) {
+            $licenseId = $e['call'] ? FccLicense::where('call_sign', $e['call'])->value('id') : null;
+            FccComplianceEvent::create([
+                'license_id' => $licenseId,
+                'event_type' => $e['event_type'],
+                'summary' => $e['summary'],
+                'actor' => $e['actor'],
+                'occurred_at' => now()->subMinutes($e['minutes_ago']),
+            ]);
+        }
+    }
+}

--- a/database/seeders/FccOperationalSeeder.php
+++ b/database/seeders/FccOperationalSeeder.php
@@ -28,10 +28,37 @@ class FccOperationalSeeder extends Seeder
 {
     public function run(): void
     {
-        $licenses = FccLicense::all()->keyBy('call_sign');
+        // After fcc:import-bulk we may have ~30K stations. Generating
+        // operational records for every station would create millions of
+        // rows. Pick a representative sample so the dashboard renders
+        // realistic compliance activity without bloating the DB.
+        //
+        // Strategy: prefer well-known reference stations (the ones we
+        // pull live via fcc:import) plus a random tail.
+        $referenceCalls = [
+            'WABC', 'WTOP', 'KCBS-FM', 'WGBH-FM', 'KQED-FM', 'WAMU',
+            'KCRW', 'KUOW', 'WHTZ', 'KFI', 'WBZ', 'KFI-AM', 'WBZ-AM',
+            'WABC-AM', 'KQED', 'WGBH',
+        ];
+
+        $referenced = FccLicense::query()
+            ->whereIn('call_sign', $referenceCalls)
+            ->get();
+
+        $extraSample = FccLicense::query()
+            ->whereNotIn('call_sign', $referenceCalls)
+            ->inRandomOrder()
+            ->limit(30 - $referenced->count())
+            ->get();
+
+        $licenses = $referenced->merge($extraSample)->keyBy('call_sign');
         if ($licenses->isEmpty()) {
             return;
         }
+
+        $this->command?->getOutput()?->writeln(
+            "  Seeding operational data for ".$licenses->count()." sample stations"
+        );
 
         // ---- ASR registrations (one per tower-bearing facility) ----
         $asrs = [

--- a/database/seeders/FccOperationalSeeder.php
+++ b/database/seeders/FccOperationalSeeder.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\FccAsrRegistration;
+use App\Models\FccEasTest;
+use App\Models\FccFormFiling;
+use App\Models\FccIssuesProgramsEntry;
+use App\Models\FccIssuesProgramsList;
+use App\Models\FccLicense;
+use App\Models\FccPoliticalFileEntry;
+use App\Models\FccPublicFileDocument;
+use App\Models\FccRegulatoryFee;
+use App\Models\FccStationLogEntry;
+use App\Models\FccTowerLightingInspection;
+use App\Models\FccTowerLightingOutage;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds operational FCC compliance data: EAS tests, public-file documents,
+ * Issues/Programs lists, ASRs, tower lighting inspections, political file
+ * entries, station log entries, regulatory fees, and form filings.
+ *
+ * The data is illustrative for demo use but realistic enough that an FCC
+ * compliance officer would recognize the workflow and required fields.
+ */
+class FccOperationalSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $licenses = FccLicense::all()->keyBy('call_sign');
+        if ($licenses->isEmpty()) {
+            return;
+        }
+
+        // ---- ASR registrations (one per tower-bearing facility) ----
+        $asrs = [
+            ['asr_number' => '1011234', 'owner' => 'Market Hall Broadcasting, LLC', 'structure_type' => 'self_supporting', 'overall_height_meters' => 308.0, 'lighting_type' => 'medium_dual', 'painting_required' => 'aviation_orange_white', 'latitude' => 32.7767, 'longitude' => -96.7970],
+            ['asr_number' => '1023456', 'owner' => 'Pioneer Media Group',           'structure_type' => 'guyed',            'overall_height_meters' => 142.0, 'lighting_type' => 'red_only',    'painting_required' => 'aviation_orange_white', 'latitude' => 42.3601, 'longitude' => -71.0589],
+            ['asr_number' => '1009876', 'owner' => 'CityView Television, Inc.',     'structure_type' => 'self_supporting', 'overall_height_meters' => 922.0, 'lighting_type' => 'high_dual',   'painting_required' => 'aviation_orange_white', 'latitude' => 34.2257, 'longitude' => -118.0586],
+            ['asr_number' => '1234567', 'owner' => 'North County Radio',            'structure_type' => 'monopole',        'overall_height_meters' => 215.0, 'lighting_type' => 'medium_dual', 'painting_required' => 'none',                  'latitude' => 32.7157, 'longitude' => -117.1611],
+            ['asr_number' => '1099877', 'owner' => 'Metro Media Group',             'structure_type' => 'guyed',            'overall_height_meters' => 411.0, 'lighting_type' => 'high_dual',   'painting_required' => 'aviation_orange_white', 'latitude' => 41.8781, 'longitude' => -87.6298],
+        ];
+        foreach ($asrs as $a) {
+            $a['last_inspection_date'] = now()->subMonths(rand(1, 3))->toDateString();
+            $a['next_inspection_due'] = now()->addMonths(3)->toDateString();
+            $a['faa_study_number'] = '20'.rand(20, 25).'-AWP-'.rand(1000, 9999).'-OE';
+            FccAsrRegistration::updateOrCreate(['asr_number' => $a['asr_number']], $a);
+        }
+
+        // ---- EAS test logs — last 12 weeks of RWTs + monthly RMTs ----
+        foreach ($licenses as $license) {
+            // Weekly RWTs for the last 12 weeks
+            for ($w = 0; $w < 12; $w++) {
+                $when = now()->subWeeks($w)->setTime(rand(8, 17), [0, 15, 30, 45][rand(0, 3)]);
+                FccEasTest::firstOrCreate(
+                    ['license_id' => $license->id, 'test_datetime' => $when, 'test_type' => 'RWT'],
+                    [
+                        'direction' => $w % 4 === 0 ? 'originated' : 'received',
+                        'originator_code' => 'EAS',
+                        'event_code' => 'RWT',
+                        'audio_intelligible' => true,
+                        'visual_message_present' => true,
+                        'logged_by' => $w % 2 === 0 ? 'C. Helstein' : 'A. Reyes',
+                    ]
+                );
+            }
+            // Monthly RMTs for the last 6 months
+            for ($m = 0; $m < 6; $m++) {
+                $when = now()->subMonths($m)->day(rand(5, 25))->setTime(rand(10, 16), 0);
+                FccEasTest::firstOrCreate(
+                    ['license_id' => $license->id, 'test_datetime' => $when, 'test_type' => 'RMT'],
+                    [
+                        'direction' => 'received',
+                        'originator_code' => 'PEP',
+                        'event_code' => 'RMT',
+                        'audio_intelligible' => true,
+                        'visual_message_present' => true,
+                        'filed_in_etrs' => $m === 0,
+                        'etrs_filed_date' => $m === 0 ? now()->subDays(rand(5, 25))->toDateString() : null,
+                        'logged_by' => 'C. Helstein',
+                    ]
+                );
+            }
+        }
+
+        // ---- Issues/Programs Lists — last 4 quarters per license ----
+        $issueBank = [
+            'Mental Health Awareness', 'Local Economy & Jobs', 'Public Safety',
+            'Housing & Affordability', 'Education', 'Infrastructure',
+            'Senior Services', 'Veteran Affairs', 'Childcare & Youth',
+            'Wildfire & Emergency Preparedness', 'Climate & Environment',
+        ];
+        foreach ($licenses as $license) {
+            for ($q = 0; $q < 4; $q++) {
+                $date = now()->subMonths($q * 3);
+                $year = $date->year;
+                $quarter = 'Q'.ceil($date->month / 3);
+
+                $list = FccIssuesProgramsList::firstOrCreate(
+                    ['license_id' => $license->id, 'quarter_year' => $year, 'quarter' => $quarter],
+                    [
+                        'placed_in_file_date' => $q === 0 ? null : $date->endOfQuarter()->addDays(rand(3, 9))->toDateString(),
+                        'status' => $q === 0 ? 'draft' : 'placed_in_file',
+                    ]
+                );
+
+                if ($list->entries()->exists()) continue;
+
+                $picked = collect($issueBank)->shuffle()->take(5);
+                foreach ($picked as $issue) {
+                    FccIssuesProgramsEntry::create([
+                        'list_id' => $list->id,
+                        'issue' => $issue,
+                        'program_title' => $issue.' — Community Spotlight',
+                        'program_description' => '15-minute interview segment featuring local leaders and stakeholders addressing '.$issue.'.',
+                        'aired_at' => $date->copy()->subDays(rand(1, 80))->setTime(rand(6, 18), 0),
+                        'duration_minutes' => [15, 30, 60][rand(0, 2)],
+                        'program_type' => ['public_affairs', 'news', 'interview'][rand(0, 2)],
+                    ]);
+                }
+            }
+        }
+
+        // ---- Public File Documents ----
+        foreach ($licenses as $license) {
+            $docs = [
+                ['document_type' => 'authorization',              'title' => 'License Authorization — '.$license->call_sign,        'document_date' => $license->grant_date,                              'uploaded_to_lms_date' => $license->grant_date],
+                ['document_type' => 'biennial_ownership_report',  'title' => 'Biennial Ownership Report (Form 323)',                'document_date' => now()->subYear()->toDateString(),                  'uploaded_to_lms_date' => now()->subYear()->addDays(2)->toDateString()],
+                ['document_type' => 'eeo_public_file',            'title' => 'Annual EEO Public File Report',                       'document_date' => now()->subMonths(2)->toDateString(),               'uploaded_to_lms_date' => now()->subMonths(2)->toDateString()],
+                ['document_type' => 'issues_programs_list',       'title' => 'Issues/Programs List — Previous Quarter',             'document_date' => now()->subMonths(3)->endOfQuarter()->toDateString(), 'uploaded_to_lms_date' => now()->subMonths(3)->endOfQuarter()->addDays(7)->toDateString()],
+                ['document_type' => 'contour_map',                'title' => 'Service Contour Map (60 dBu / 54 dBu)',               'document_date' => $license->grant_date],
+            ];
+            foreach ($docs as $d) {
+                $d['license_id'] = $license->id;
+                $d['retention_until'] = $license->expiration_date;
+                $d['uploaded_by'] = 'C. Helstein';
+                $d['lms_url'] = 'https://publicfiles.fcc.gov/'.strtolower($license->call_sign).'/'.uniqid();
+                FccPublicFileDocument::firstOrCreate(
+                    ['license_id' => $license->id, 'document_type' => $d['document_type'], 'title' => $d['title']],
+                    $d
+                );
+            }
+        }
+
+        // ---- Tower Lighting Inspections — quarterly per ASR ----
+        $facilityIdsByAsr = [];
+        foreach (FccAsrRegistration::all() as $asr) {
+            for ($q = 0; $q < 4; $q++) {
+                $insp = $asr->last_inspection_date
+                    ? \Illuminate\Support\Carbon::parse($asr->last_inspection_date)->subMonths($q * 3)
+                    : now()->subMonths($q * 3);
+                FccTowerLightingInspection::firstOrCreate(
+                    ['asr_registration_id' => $asr->id, 'inspection_date' => $insp->toDateString()],
+                    [
+                        'inspector_name' => 'C. Helstein, CPBE',
+                        'result' => $q === 0 && $asr->asr_number === '1234567' ? 'minor_issue' : 'operational',
+                        'automatic_monitor_observed' => true,
+                        'manual_observation_performed' => true,
+                        'next_inspection_due' => $insp->copy()->addMonths(3)->toDateString(),
+                        'findings' => $q === 0 && $asr->asr_number === '1234567'
+                            ? 'L-810 side marker on south leg observed flickering during nightly auto-test.'
+                            : 'All beacons and side markers operating per FAA Style A spec.',
+                    ]
+                );
+            }
+        }
+
+        // One outage on the North County tower
+        $ncAsr = FccAsrRegistration::where('asr_number', '1234567')->first();
+        if ($ncAsr) {
+            FccTowerLightingOutage::firstOrCreate(
+                ['asr_registration_id' => $ncAsr->id, 'outage_observed_at' => now()->subDays(9)->setTime(2, 14)],
+                [
+                    'faa_notified_at' => now()->subDays(9)->setTime(2, 47),
+                    'notam_number' => '!SAN 06/' . str_pad((string) rand(100, 999), 3, '0', STR_PAD_LEFT),
+                    'repaired_at' => now()->subDays(7)->setTime(11, 0),
+                    'faa_cancellation_at' => now()->subDays(7)->setTime(11, 22),
+                    'failure_type' => 'side_marker',
+                    'cause' => 'L-810 LED module degraded; replaced under spare-parts inventory.',
+                    'actions_taken' => 'NOTAM issued through Lockheed Flight Service. Tower crew dispatched next business day.',
+                ]
+            );
+        }
+
+        // ---- Political File Entries (focused on stations in election windows) ----
+        $political = [
+            ['call' => 'KXYZ-FM', 'candidate' => 'Sarah Chen for U.S. Senate (TX-D)',     'sponsor' => 'Chen for Senate',           'office' => 'federal_senate',  'spots' => 220, 'rate' => 185.00],
+            ['call' => 'WABC-AM', 'candidate' => 'Friends of Marcus Hill (R-MA)',          'sponsor' => 'Marcus Hill Committee',     'office' => 'federal_house',   'spots' => 140, 'rate' => 95.00],
+            ['call' => 'WQRS-TV', 'candidate' => 'CA Proposition 19 — Yes',                'sponsor' => 'Yes on 19 Coalition',       'office' => 'ballot_initiative','spots' => 60,  'rate' => 1450.00],
+            ['call' => 'KDEF-FM', 'candidate' => 'San Diego City Council Dist. 3 — Park',  'sponsor' => 'Park for Council',          'office' => 'local',           'spots' => 75,  'rate' => 42.00],
+            ['call' => 'KJKL-TV', 'candidate' => 'IL Gubernatorial — Rivera (D)',          'sponsor' => 'Rivera for Illinois',       'office' => 'state_governor',  'spots' => 90,  'rate' => 980.00],
+        ];
+        foreach ($political as $p) {
+            $license = $licenses[$p['call']] ?? null;
+            if (! $license) continue;
+            FccPoliticalFileEntry::firstOrCreate(
+                ['license_id' => $license->id, 'candidate_or_issue' => $p['candidate'], 'order_date' => now()->subDays(rand(5, 35))->toDateString()],
+                [
+                    'sponsor' => $p['sponsor'],
+                    'office' => $p['office'],
+                    'flight_start_date' => now()->subDays(rand(0, 7))->toDateString(),
+                    'flight_end_date' => now()->addDays(rand(7, 30))->toDateString(),
+                    'spots_purchased' => $p['spots'],
+                    'rate_per_spot' => $p['rate'],
+                    'total_amount' => round($p['spots'] * $p['rate'], 2),
+                    'lowest_unit_rate_window' => true,
+                    'uploaded_to_public_file_date' => now()->subDays(rand(0, 5))->toDateString(),
+                ]
+            );
+        }
+
+        // ---- Station log entries — recent transmitter readings + EAS + tower ----
+        foreach ($licenses as $license) {
+            for ($d = 0; $d < 7; $d++) {
+                FccStationLogEntry::create([
+                    'license_id' => $license->id,
+                    'logged_at' => now()->subDays($d)->setTime(8, 0),
+                    'entry_type' => 'transmitter_reading',
+                    'summary' => 'Morning transmitter readings logged.',
+                    'readings' => [
+                        'plate_voltage' => rand(7800, 8200),
+                        'plate_current' => round(rand(2200, 2600) / 1000, 2),
+                        'forward_power_kw' => round(rand(900, 1010) / 100, 2),
+                        'reflected_power_w' => rand(15, 95),
+                        'swr' => round(1 + rand(2, 12) / 100, 2),
+                    ],
+                    'logged_by' => 'C. Helstein',
+                ]);
+            }
+            FccStationLogEntry::create([
+                'license_id' => $license->id,
+                'logged_at' => now()->subDays(2)->setTime(14, 30),
+                'entry_type' => 'tower_lighting_check',
+                'summary' => 'Auto-monitor confirmed all beacons operational at sunset transition.',
+                'logged_by' => 'C. Helstein',
+            ]);
+        }
+
+        // ---- Regulatory fees — current FY ----
+        $feeMap = [
+            'AM' => ['cat' => 'AM Class B', 'amt' => 1075.00],
+            'FM' => ['cat' => 'FM Class C / C0', 'amt' => 4500.00],
+            'TV' => ['cat' => 'TV Markets 1-10 (UHF)', 'amt' => 17800.00],
+            'LPFM' => ['cat' => 'LPFM', 'amt' => 535.00],
+            'LPTV' => ['cat' => 'LPTV / TV Translator', 'amt' => 535.00],
+        ];
+        foreach ($licenses as $license) {
+            $row = $feeMap[$license->service] ?? ['cat' => 'Other Broadcast', 'amt' => 1000.00];
+            FccRegulatoryFee::firstOrCreate(
+                ['license_id' => $license->id, 'fiscal_year' => now()->year],
+                [
+                    'fee_category' => $row['cat'],
+                    'amount_due' => $row['amt'],
+                    'amount_paid' => $license->status === 'non_compliant' ? 0 : $row['amt'],
+                    'due_date' => now()->month <= 9 ? now()->setMonth(9)->setDay(28)->toDateString() : now()->addYear()->setMonth(9)->setDay(28)->toDateString(),
+                    'paid_date' => $license->status === 'non_compliant' ? null : now()->subMonths(rand(1, 6))->toDateString(),
+                    'confirmation_number' => $license->status === 'non_compliant' ? null : 'PG-'.strtoupper(substr(md5($license->call_sign), 0, 9)),
+                    'status' => $license->status === 'non_compliant' ? 'overdue' : 'paid',
+                ]
+            );
+        }
+
+        // ---- Recent form filings ----
+        foreach ($licenses as $license) {
+            FccFormFiling::firstOrCreate(
+                ['license_id' => $license->id, 'form_number' => '323', 'filed_date' => now()->subYear()->toDateString()],
+                [
+                    'form_title' => 'Biennial Ownership Report (Commercial)',
+                    'file_number' => '00000'.rand(10000, 99999).'-'.rand(100, 999),
+                    'status' => 'granted',
+                    'filed_by' => 'C. Helstein',
+                ]
+            );
+            FccFormFiling::firstOrCreate(
+                ['license_id' => $license->id, 'form_number' => '397', 'filed_date' => now()->subMonths(4)->toDateString()],
+                [
+                    'form_title' => 'EEO Annual Report',
+                    'status' => 'filed',
+                    'filed_by' => 'C. Helstein',
+                ]
+            );
+        }
+    }
+}

--- a/docs/FCC-DEPLOY.md
+++ b/docs/FCC-DEPLOY.md
@@ -1,0 +1,124 @@
+# OpenGRC FCC Compliance — Full-USA Deploy
+
+This guide gets the FCC reskin running on a server with **every U.S.
+broadcast station** populated as real data from FCC's public sources.
+
+## Prerequisites
+
+- PHP 8.4 (Composer requires it)
+- Node 18+ (for Vite)
+- SQLite or MySQL (default config uses SQLite)
+- Outbound HTTPS to `transition.fcc.gov` and `data.fcc.gov`
+  (verify with: `curl -sI -A curl/8.5.0 https://transition.fcc.gov/Bureaus/MB/Databases/cdbs/facility.zip`)
+
+## One-time setup
+
+```bash
+cd /var/www/opengrc
+sudo -u www-data git fetch chelstein claude/reskin-open-grc-ZQtUH
+sudo -u www-data git checkout -b fcc-reskin chelstein/claude/reskin-open-grc-ZQtUH
+
+sudo -u www-data composer install --no-dev --optimize-autoloader
+sudo -u www-data npm ci
+sudo -u www-data NODE_OPTIONS=--max-old-space-size=2048 npx vite build
+
+sudo -u www-data php artisan migrate --force
+sudo -u www-data php artisan optimize:clear
+sudo -u www-data php artisan filament:cache-components
+sudo -u www-data php artisan config:cache
+sudo -u www-data php artisan view:cache
+sudo systemctl reload php8.4-fpm
+```
+
+## Populate real FCC data
+
+### Quick smoke test (1-2 minutes, ~600 stations)
+
+```bash
+sudo -u www-data php artisan fcc:sync --quick
+```
+
+### Full sync — every U.S. broadcast station (~10 minutes, ~30K stations)
+
+```bash
+sudo -u www-data php artisan fcc:sync
+```
+
+This pulls:
+- **CDBS** (`transition.fcc.gov/Bureaus/MB/Databases/cdbs/`):
+  - `facility.zip` (~3 MB) — every broadcast facility
+  - `am_eng_data.zip`, `fm_eng_data.zip`, `tv_eng_data.zip` — engineering
+    (lat/lon, ERP, HAAT, AMSL)
+  - `party.zip` + `fac_party.zip` (~16 MB) — licensee names
+- **ULS** (`data.fcc.gov/download/pub/uls/complete/`):
+  - `r_tower.zip`, `a_tower.zip` — every Antenna Structure Registration
+- Operational seeder generates realistic EAS / Issues-Programs / Public
+  File / station-log / political-file / reg-fee / form-filing records
+  for a representative 30-station sample.
+
+### Individual commands
+
+```bash
+# All ~30K broadcast facilities + licenses
+sudo -u www-data php artisan fcc:import-bulk
+sudo -u www-data php artisan fcc:import-bulk --service=fm        # FM only
+sudo -u www-data php artisan fcc:import-bulk --limit=500         # smoke test
+sudo -u www-data php artisan fcc:import-bulk --skip-licensees    # faster
+sudo -u www-data php artisan fcc:import-bulk --skip-download     # use cache
+
+# All Antenna Structure Registrations
+sudo -u www-data php artisan fcc:import-asr
+sudo -u www-data php artisan fcc:import-asr --limit=200          # smoke test
+
+# Single-station live lookup (transition.fcc.gov FM/AM/TV Query)
+sudo -u www-data php artisan fcc:import --calls=KQED,WTOP-FM,WBZ-AM
+```
+
+## Verify
+
+```bash
+sudo -u www-data sqlite3 database/opengrc.sqlite "SELECT COUNT(*) FROM fcc_licenses;"
+sudo -u www-data sqlite3 database/opengrc.sqlite "SELECT COUNT(*) FROM fcc_facilities;"
+sudo -u www-data sqlite3 database/opengrc.sqlite "SELECT COUNT(*) FROM fcc_asr_registrations;"
+sudo -u www-data sqlite3 database/opengrc.sqlite \
+  "SELECT call_sign, service, channel_or_frequency, licensee FROM fcc_licenses LIMIT 10;"
+```
+
+After hard-refresh of `https://your-server/app/dashboard` you should see:
+- **Licenses** count ~30K (real)
+- **Facilities** ~30K with HAAT / AMSL / coordinates from CDBS
+- **ASR Registrations** ~100K real towers
+- License Compliance table on dashboard shows the 25 worst-compliance
+  stations (sorted non_compliant → at_risk → expiring_soon → active)
+- The full list paginated under FCC Compliance > Licenses
+
+## What's real vs synthetic
+
+| Data | Source | Real? |
+|------|--------|-------|
+| Call signs / facility IDs | CDBS facility.dat | ✅ Real |
+| Frequency / channel | CDBS facility.dat | ✅ Real |
+| Lat/lon / HAAT / AMSL | CDBS {fm,am,tv}_eng_data.dat | ✅ Real |
+| Licensee names | CDBS party.dat + fac_party.dat | ✅ Real |
+| License expiration dates | CDBS facility.dat | ✅ Real |
+| ASR # / structure type / height | ULS r_tower.zip | ✅ Real |
+| 47 CFR rule numbers + titles | Hand-coded from CFR | ✅ Real |
+| Compliance scores | Synthetic (so dashboard renders mix) | ⚠️ Demo |
+| EAS test logs | Synthetic per sample station | ⚠️ Demo |
+| Issues/Programs lists | Synthetic per sample station | ⚠️ Demo |
+| Political file entries | Synthetic per sample station | ⚠️ Demo |
+| Tower inspections | Synthetic per ASR sample | ⚠️ Demo |
+
+The compliance/operational data is illustrative — a real deployment
+would replace those seeders with a feed from the station's own EAS
+ENDEC, public file ingest, etc.
+
+## Refreshing data
+
+CDBS dumps are updated nightly by the FCC. Re-run `fcc:sync` weekly
+(or daily via cron) to keep the database current:
+
+```cron
+# /etc/cron.d/fcc-sync
+0 6 * * * www-data /usr/bin/php /var/www/opengrc/artisan fcc:sync >> /var/log/fcc-sync.log 2>&1
+```

--- a/docs/FCC-DEPLOY.md
+++ b/docs/FCC-DEPLOY.md
@@ -70,7 +70,13 @@ sudo -u www-data php artisan fcc:import-bulk --skip-download     # use cache
 sudo -u www-data php artisan fcc:import-asr
 sudo -u www-data php artisan fcc:import-asr --limit=200          # smoke test
 
-# Single-station live lookup (transition.fcc.gov FM/AM/TV Query)
+# LMS augmentation — adds FRN per facility (rate-limited, resumable)
+sudo -u www-data php artisan fcc:import-lms                       # all missing FRN
+sudo -u www-data php artisan fcc:import-lms --limit=1000          # one batch
+sudo -u www-data php artisan fcc:import-lms --calls=KQED,WTOP     # specific
+sudo -u www-data php artisan fcc:import-lms --sleep=500           # 500ms between requests
+
+# Single-station live lookup (transition.fcc.gov FM/AM/TV Query — also LMS-backed)
 sudo -u www-data php artisan fcc:import --calls=KQED,WTOP-FM,WBZ-AM
 ```
 
@@ -102,6 +108,7 @@ After hard-refresh of `https://your-server/app/dashboard` you should see:
 | Licensee names | CDBS party.dat + fac_party.dat | ✅ Real |
 | License expiration dates | CDBS facility.dat | ✅ Real |
 | ASR # / structure type / height | ULS r_tower.zip | ✅ Real |
+| FRN per license | LMS publicFacilityDetails (per-facility scrape) | ✅ Real (run fcc:import-lms) |
 | 47 CFR rule numbers + titles | Hand-coded from CFR | ✅ Real |
 | Compliance scores | Synthetic (so dashboard renders mix) | ⚠️ Demo |
 | EAS test logs | Synthetic per sample station | ⚠️ Demo |

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -452,3 +452,38 @@ a.fi-logo, .fi-logo {
 }
 
 /* Compliance status badges remain colorful — leave them alone */
+
+/* Hide non-FCC sidebar entries on the App panel so the sidebar leads
+   with FCC Compliance. The underlying pages still work via direct URL. */
+.fi-sidebar-item:has(a[href*="/app/to-do"]),
+.fi-sidebar-item:has(a[href$="/app/risks"]),
+.fi-sidebar-item:has(a[href*="/app/risks?"]),
+.fi-sidebar-item:has(a[href*="/app/vendor-manager"]),
+.fi-sidebar-item:has(a[href*="/app/trust-center-manager"]) {
+    display: none !important;
+}
+
+/* Topbar alerts badge styling */
+.fi-fcc-alerts-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
+    background-color: rgba(251, 191, 36, 0.1);
+    border: 1px solid rgba(251, 191, 36, 0.3);
+    color: #fbbf24;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color 150ms;
+}
+.fi-fcc-alerts-badge:hover {
+    background-color: rgba(251, 191, 36, 0.2);
+    color: #fcd34d;
+}
+.fi-fcc-alerts-badge.is-critical {
+    background-color: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #f87171;
+}

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -347,20 +347,35 @@ body, .fi-body, .fi-main-ctn, .fi-page, main {
     color: rgb(156 163 175) !important;
 }
 
-/* Tables on dark canvas */
+/* Tables on dark canvas - high contrast */
 .fi-ta-table,
 .fi-ta-header-cell,
 .fi-ta-row,
 .fi-ta-cell {
     background-color: transparent !important;
-    color: rgb(229 231 235) !important;
+    color: #f3f4f6 !important;
 }
+
+/* Make sure inner text spans inherit the bright color */
+.fi-ta-cell *,
+.fi-ta-text,
+.fi-ta-text-item-label,
+.fi-ta-text-prefix,
+.fi-ta-text-suffix {
+    color: #f3f4f6 !important;
+}
+
+/* Keep colored states (success/warning/danger badges) visible */
+.fi-ta-cell .fi-color-success { color: #4ade80 !important; }
+.fi-ta-cell .fi-color-warning { color: #fbbf24 !important; }
+.fi-ta-cell .fi-color-danger  { color: #f87171 !important; }
+.fi-ta-cell .fi-color-info    { color: #38bdf8 !important; }
 
 .fi-ta-header {
     background-color: #050d1f !important;
 }
 
-.fi-ta-header-cell {
+.fi-ta-header-cell, .fi-ta-header-cell * {
     color: #fbbf24 !important;
     text-transform: uppercase;
     font-size: 0.7rem;
@@ -373,6 +388,21 @@ body, .fi-body, .fi-main-ctn, .fi-page, main {
 
 .fi-ta-row:hover {
     background-color: rgba(251, 191, 36, 0.04) !important;
+}
+
+/* Section headers (the "License Compliance" titles) need to pop */
+.fi-section-header-heading,
+.fi-section-header-heading *,
+h2.fi-section-header-heading,
+h3.fi-section-header-heading {
+    color: #f3f4f6 !important;
+    font-weight: 600 !important;
+    font-size: 1.05rem !important;
+}
+
+.fi-section-header-description,
+.fi-section-header-description * {
+    color: #9ca3af !important;
 }
 
 /* Form inputs on dark canvas */

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -6,18 +6,32 @@
 @source '../../../../storage/framework/views/*.php';
 @source '../../../../vendor/filament/**/*.blade.php';
 
-/* Define custom grcblue color palette */
+/* OpenGRC FCC Compliance reskin - navy & gold palette.
+   The legacy `grcblue` token names are retained for backwards compatibility
+   with existing markup, but now resolve to a deep-navy ramp. A new `grcgold`
+   ramp powers the amber accents seen on the FCC Compliance dashboard. */
 @theme {
-    --color-grcblue-50: #eaf3f7;
-    --color-grcblue-100: #d4e7ef;
-    --color-grcblue-200: #d4e7ef;
-    --color-grcblue-300: #7eb7d1;
-    --color-grcblue-400: #1375a0;
-    --color-grcblue-500: #1375a0;
-    --color-grcblue-600: #0f5a7a;
-    --color-grcblue-700: #0c4a65;
-    --color-grcblue-800: #374151;
-    --color-grcblue-900: #212a3a;
+    --color-grcblue-50: #e6ecf5;
+    --color-grcblue-100: #c4d1e6;
+    --color-grcblue-200: #8fa6c9;
+    --color-grcblue-300: #5a7bac;
+    --color-grcblue-400: #2c4d80;
+    --color-grcblue-500: #1a3666;
+    --color-grcblue-600: #122a52;
+    --color-grcblue-700: #0c1f3d;
+    --color-grcblue-800: #0a1830;
+    --color-grcblue-900: #050d1f;
+
+    --color-grcgold-50: #fffbeb;
+    --color-grcgold-100: #fef3c7;
+    --color-grcgold-200: #fde68a;
+    --color-grcgold-300: #fcd34d;
+    --color-grcgold-400: #fbbf24;
+    --color-grcgold-500: #f59e0b;
+    --color-grcgold-600: #d97706;
+    --color-grcgold-700: #b45309;
+    --color-grcgold-800: #92400e;
+    --color-grcgold-900: #78350f;
 }
 
 
@@ -28,45 +42,62 @@
     font-style: normal;
 }
 
-/* GRC Blue color utilities - defined with !important for override */
+/* Navy text/background utilities (legacy class names kept). */
 .text-grcblue-800 {
-    color: #374151 !important;
+    color: #0a1830 !important;
 }
 
 .text-grcblue-400 {
-    color: #1375a0 !important;
+    color: #fbbf24 !important;
 }
 
 .bg-grcblue-200 {
-    background-color: #d4e7ef !important;
+    background-color: #8fa6c9 !important;
 }
 
 .bg-grcblue-400 {
-    background-color: #1375a0 !important;
+    background-color: #2c4d80 !important;
 }
 
 .bg-grcblue-500 {
-    background-color: #1375a0 !important;
+    background-color: #1a3666 !important;
 }
 
 .bg-grcblue-600 {
-    background-color: #0f5a7a !important;
+    background-color: #122a52 !important;
 }
 
 .bg-grcblue-700 {
-    background-color: #0c4a65 !important;
+    background-color: #0c1f3d !important;
 }
 
 .bg-grcblue-800 {
-    background-color: #374151 !important;
+    background-color: #0a1830 !important;
 }
 
 .hover\:bg-grcblue-600:hover {
-    background-color: #0f5a7a !important;
+    background-color: #122a52 !important;
 }
 
 .hover\:bg-grcblue-700:hover {
-    background-color: #0c4a65 !important;
+    background-color: #0c1f3d !important;
+}
+
+/* Gold accent utilities. */
+.text-grcgold-400 {
+    color: #fbbf24 !important;
+}
+
+.bg-grcgold-400 {
+    background-color: #fbbf24 !important;
+}
+
+.bg-grcgold-500 {
+    background-color: #f59e0b !important;
+}
+
+.hover\:bg-grcgold-500:hover {
+    background-color: #f59e0b !important;
 }
 
 /* Control description text formatting */
@@ -88,43 +119,71 @@
     margin-bottom: 1rem;
 }
 
-/* Sidebar Styles */
+/* Sidebar - deep navy in both light and dark modes to match FCC dashboard */
 .fi-sidebar {
-    background-color: #374151 !important;
+    background-color: #0a1830 !important;
+    border-right: 1px solid rgba(251, 191, 36, 0.08) !important;
 }
 
 .dark .fi-sidebar {
-    background-color: rgb(17 24 39) !important;
+    background-color: #050d1f !important;
 }
 
 .fi-sidebar-item-label {
-    color: rgb(243 244 246) !important;
+    color: rgb(229 231 235) !important;
 }
 
 li.fi-sidebar-item.fi-active > a {
-    background-color: #1375a0 !important;
+    background-color: rgba(251, 191, 36, 0.12) !important;
+    border-left: 3px solid #fbbf24 !important;
+}
+
+li.fi-sidebar-item.fi-active > a .fi-sidebar-item-label {
+    color: #fbbf24 !important;
 }
 
 .fi-sidebar-item > a:hover {
-    @apply bg-primary-600 text-black transition-colors duration-200;
+    background-color: rgba(251, 191, 36, 0.08) !important;
+    color: #fbbf24 !important;
+    transition: background-color 200ms, color 200ms;
 }
 
 .fi-sidebar-group-label {
-    color: rgb(209 213 219) !important;
+    color: #fbbf24 !important;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.7rem;
+}
+
+/* Topbar / branding */
+.fi-topbar {
+    background-color: #0a1830 !important;
+    border-bottom: 1px solid rgba(251, 191, 36, 0.08) !important;
+}
+
+.dark .fi-topbar {
+    background-color: #050d1f !important;
+}
+
+.fi-topbar a, .fi-topbar button {
+    color: rgb(229 231 235);
 }
 
 /* Form Label */
 div.flex.items-center.gap-x-3.justify-between > dt > span {
-    color: #374151 !important;
+    color: #0a1830 !important;
     font-weight: bold;
 }
 
 .dark div.flex.items-center.gap-x-3.justify-between > dt > span {
-    color: #1375a0 !important;
+    color: #fbbf24 !important;
 }
 
 a.fi-logo {
     font-family: 'Bruno Ace SC', sans-serif;
+    color: #fbbf24 !important;
+    letter-spacing: 0.04em;
 }
 
 /* Custom Risk Colors */
@@ -177,38 +236,61 @@ a.fi-logo {
 }
 
 .fi-color-grcblue {
-    background-color: #1375a0 !important;
-    color: #ffffff;
+    background-color: #0c1f3d !important;
+    color: #fbbf24;
 }
 
 .fi-color-grcblue:hover {
-    background-color: #a8d4ea !important;
-    color: #ffffff;
+    background-color: #122a52 !important;
+    color: #fcd34d;
 }
 
 .fi-color-bg-grcblue-200 {
-    background-color: #d4e7ef !important;
-    color: #000000;
+    background-color: #8fa6c9 !important;
+    color: #050d1f;
 }
 
-/* Custom sidebar scrollbar */
+/* Primary action buttons - amber/gold accent like the FCC "Export" CTA */
+.fi-btn-color-primary {
+    background-color: #fbbf24 !important;
+    color: #0a1830 !important;
+    border-color: #f59e0b !important;
+}
+
+.fi-btn-color-primary:hover {
+    background-color: #f59e0b !important;
+    color: #050d1f !important;
+}
+
+/* Stat widget headings */
+.fi-wi-stats-overview-stat-value {
+    color: #fbbf24 !important;
+    font-weight: 700;
+}
+
+.dark .fi-wi-stats-overview-stat {
+    background-color: #0c1f3d !important;
+    border: 1px solid rgba(251, 191, 36, 0.1);
+}
+
+/* Custom sidebar scrollbar - navy with gold hover */
 .fi-sidebar-nav {
     scrollbar-width: thin;
-    scrollbar-color: #374151 #232e3c;
+    scrollbar-color: #122a52 #0a1830;
 }
 
 .fi-sidebar-nav::-webkit-scrollbar {
     width: 8px;
-    background: #232e3c;
+    background: #0a1830;
 }
 
 .fi-sidebar-nav::-webkit-scrollbar-thumb {
-    background: #374151;
+    background: #122a52;
     border-radius: 6px;
 }
 
 .fi-sidebar-nav::-webkit-scrollbar-thumb:hover {
-    background: #1375a0;
+    background: #fbbf24;
 }
 
 /* Prevent inactivity guard wrapper from taking up space when modal is inactive */
@@ -217,9 +299,9 @@ a.fi-logo {
     font-size: 0;
 }
 
-/* Use white for active sidebar icons for better contrast (austin-liminal) */
+/* Active sidebar icons in gold for stronger contrast on navy */
 .fi-sidebar-item.fi-active .fi-sidebar-item-icon {
-    color: white !important;
+    color: #fbbf24 !important;
 }
 
 /* Make page transition instant (F4 no longer has transition-all class) */

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -308,3 +308,117 @@ a.fi-logo {
 .fi-main-ctn {
     transition-duration: 0s !important;
 }
+
+/* ----------------------------------------------------------------------- */
+/* Force the navy/gold canvas in BOTH light and dark mode so the FCC look  */
+/* is consistent regardless of the user's theme preference.                */
+/* ----------------------------------------------------------------------- */
+
+body, .fi-body, .fi-main-ctn, .fi-page, main {
+    background-color: #0a1830 !important;
+    color: rgb(229 231 235) !important;
+}
+
+/* Section / card backgrounds — dark with subtle gold border */
+.fi-section,
+.fi-wi-stats-overview-stat,
+.fi-fo-section,
+.fi-in-section,
+.fi-ta-ctn,
+.fi-table {
+    background-color: #0c1f3d !important;
+    border: 1px solid rgba(251, 191, 36, 0.12) !important;
+    color: rgb(229 231 235) !important;
+}
+
+.fi-section-header-heading,
+.fi-section-header-description,
+.fi-wi-stats-overview-stat-label {
+    color: rgb(229 231 235) !important;
+}
+
+.fi-wi-stats-overview-stat-value {
+    color: #fbbf24 !important;
+    font-weight: 700;
+    font-size: 2.25rem;
+}
+
+.fi-wi-stats-overview-stat-description {
+    color: rgb(156 163 175) !important;
+}
+
+/* Tables on dark canvas */
+.fi-ta-table,
+.fi-ta-header-cell,
+.fi-ta-row,
+.fi-ta-cell {
+    background-color: transparent !important;
+    color: rgb(229 231 235) !important;
+}
+
+.fi-ta-header {
+    background-color: #050d1f !important;
+}
+
+.fi-ta-header-cell {
+    color: #fbbf24 !important;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.05em;
+}
+
+.fi-ta-row {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
+}
+
+.fi-ta-row:hover {
+    background-color: rgba(251, 191, 36, 0.04) !important;
+}
+
+/* Form inputs on dark canvas */
+.fi-input,
+.fi-select-input,
+.fi-textarea-input {
+    background-color: #050d1f !important;
+    color: rgb(229 231 235) !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.fi-input::placeholder {
+    color: rgb(107 114 128) !important;
+}
+
+/* Dropdown panels */
+.fi-dropdown-panel {
+    background-color: #0c1f3d !important;
+    border: 1px solid rgba(251, 191, 36, 0.15) !important;
+}
+
+/* Page heading */
+.fi-header-heading,
+.fi-header h1,
+h1.fi-header-heading {
+    color: rgb(243 244 246) !important;
+}
+
+.fi-breadcrumbs-item, .fi-breadcrumbs-separator {
+    color: rgb(156 163 175) !important;
+}
+
+/* Brand text in topbar */
+a.fi-logo, .fi-logo {
+    color: #fbbf24 !important;
+}
+
+/* Modal */
+.fi-modal-window {
+    background-color: #0c1f3d !important;
+    color: rgb(229 231 235) !important;
+}
+
+/* Pagination */
+.fi-pagination, .fi-pagination button, .fi-pagination a {
+    color: rgb(229 231 235) !important;
+}
+
+/* Compliance status badges remain colorful — leave them alone */

--- a/resources/views/filament/footer/fcc-compliance-strip.blade.php
+++ b/resources/views/filament/footer/fcc-compliance-strip.blade.php
@@ -1,0 +1,27 @@
+<div class="border-t border-amber-400/20 bg-[#050d1f] text-xs">
+    <div class="mx-auto flex flex-wrap items-center justify-between gap-4 px-6 py-3 text-gray-400">
+        <div class="flex items-center gap-2">
+            <x-filament::icon icon="heroicon-o-shield-check" class="h-4 w-4 text-amber-400" />
+            <span class="font-semibold uppercase tracking-wide text-gray-200">Data Integrity</span>
+            <span>Verified &amp; Encrypted</span>
+        </div>
+        <div class="flex items-center gap-2">
+            <x-filament::icon icon="heroicon-o-circle-stack" class="h-4 w-4 text-amber-400" />
+            <span class="font-semibold uppercase tracking-wide text-gray-200">Source</span>
+            <span>FCC Systems (LMS, ULS, ASR)</span>
+        </div>
+        <div class="flex items-center gap-2">
+            <x-filament::icon icon="heroicon-o-arrow-path" class="h-4 w-4 text-amber-400" />
+            <span class="font-semibold uppercase tracking-wide text-gray-200">Last Refresh</span>
+            <span>{{ now()->diffForHumans() }}</span>
+        </div>
+        <div class="flex items-center gap-3 text-gray-300">
+            <span class="font-semibold uppercase tracking-wide text-amber-400">Secure</span>
+            <span class="text-gray-600">|</span>
+            <span class="font-semibold uppercase tracking-wide text-amber-400">Compliant</span>
+            <span class="text-gray-600">|</span>
+            <span class="font-semibold uppercase tracking-wide text-amber-400">Trusted</span>
+            <span class="ml-3 hidden md:inline text-gray-500">Built for FCC Compliance Professionals</span>
+        </div>
+    </div>
+</div>

--- a/resources/views/filament/pages/fcc-dashboard.blade.php
+++ b/resources/views/filament/pages/fcc-dashboard.blade.php
@@ -1,0 +1,354 @@
+<x-filament-panels::page>
+    {{-- ============================================================== --}}
+    {{-- OpenGRC FCC Compliance — custom dashboard view                  --}}
+    {{-- Hand-built grid matching the FCC Compliance mockup, with all    --}}
+    {{-- click-throughs wired to underlying Filament resources.          --}}
+    {{-- ============================================================== --}}
+
+    @php
+        $licenseIndex = \App\Filament\Resources\FccLicenseResource::getUrl('index');
+        $rulesIndex = \App\Filament\Resources\FccRuleResource::getUrl('index');
+        $deadlinesIndex = \App\Filament\Resources\FccDeadlineResource::getUrl('index');
+
+        $statusBadge = function (string $status) {
+            return match ($status) {
+                'active'        => ['label' => 'Active',        'dot' => 'bg-emerald-400', 'text' => 'text-emerald-300'],
+                'expiring_soon' => ['label' => 'Expiring Soon', 'dot' => 'bg-amber-400',   'text' => 'text-amber-300'],
+                'at_risk'       => ['label' => 'At Risk',       'dot' => 'bg-amber-400',   'text' => 'text-amber-300'],
+                'non_compliant' => ['label' => 'Non-Compliant', 'dot' => 'bg-red-400',     'text' => 'text-red-300'],
+                'silent'        => ['label' => 'Silent',        'dot' => 'bg-gray-400',    'text' => 'text-gray-300'],
+                'cancelled'     => ['label' => 'Cancelled',     'dot' => 'bg-gray-500',    'text' => 'text-gray-400'],
+                default         => ['label' => ucfirst($status),'dot' => 'bg-gray-400',    'text' => 'text-gray-300'],
+            };
+        };
+
+        $serviceBadge = fn ($s) => 'inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-amber-400/15 text-amber-300 border border-amber-400/30';
+
+        $scoreColor = fn ($pct) => $pct >= 95 ? 'text-emerald-400' : ($pct >= 80 ? 'text-amber-300' : 'text-red-400');
+        $barColor   = fn ($pct) => $pct >= 95 ? 'bg-emerald-400'   : ($pct >= 80 ? 'bg-amber-400'   : 'bg-red-400');
+    @endphp
+
+    {{-- ============================================================ --}}
+    {{-- Top stat row                                                  --}}
+    {{-- ============================================================ --}}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4">
+        {{-- Overall Compliance --}}
+        <a href="{{ $licenseIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/20 p-4 hover:border-amber-400/50 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-amber-400 font-semibold">
+                    <span>Overall Compliance</span>
+                    <x-filament::icon icon="heroicon-o-shield-check" class="h-4 w-4 text-amber-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold {{ $scoreColor($overallPct) }}">{{ $overallPct }}%</div>
+                <div class="mt-1 text-xs text-gray-400">Compliant</div>
+            </div>
+        </a>
+
+        {{-- Licenses --}}
+        <a href="{{ $licenseIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/20 p-4 hover:border-amber-400/50 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-amber-400 font-semibold">
+                    <span>Licenses</span>
+                    <x-filament::icon icon="heroicon-o-identification" class="h-4 w-4 text-amber-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold text-amber-400">{{ number_format($totalLicenses) }}</div>
+                <div class="mt-1 text-xs text-gray-400">Active authorizations</div>
+            </div>
+        </a>
+
+        {{-- Rule Requirements --}}
+        <a href="{{ $rulesIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/20 p-4 hover:border-amber-400/50 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-amber-400 font-semibold">
+                    <span>Rule Requirements</span>
+                    <x-filament::icon icon="heroicon-o-scale" class="h-4 w-4 text-amber-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold text-amber-400">{{ number_format($totalRules) }}</div>
+                <div class="mt-1 text-xs text-gray-400">Total tracked</div>
+            </div>
+        </a>
+
+        {{-- Compliant --}}
+        <a href="{{ $rulesIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-emerald-400/20 p-4 hover:border-emerald-400/50 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-emerald-400 font-semibold">
+                    <span>Compliant</span>
+                    <x-filament::icon icon="heroicon-o-check-circle" class="h-4 w-4 text-emerald-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold text-emerald-400">{{ number_format($compliant) }}</div>
+                <div class="mt-1 text-xs text-gray-400">{{ $totalCompliantPct }}%</div>
+            </div>
+        </a>
+
+        {{-- At Risk --}}
+        <a href="{{ $rulesIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/30 p-4 hover:border-amber-400/60 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-amber-400 font-semibold">
+                    <span>At Risk</span>
+                    <x-filament::icon icon="heroicon-o-exclamation-triangle" class="h-4 w-4 text-amber-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold text-amber-400">{{ number_format($atRisk) }}</div>
+                <div class="mt-1 text-xs text-gray-400">{{ $totalAtRiskPct }}%</div>
+            </div>
+        </a>
+
+        {{-- Non-Compliant --}}
+        <a href="{{ $rulesIndex }}" class="block group">
+            <div class="rounded-xl bg-[#0c1f3d] border border-red-400/30 p-4 hover:border-red-400/60 transition">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wide text-red-400 font-semibold">
+                    <span>Non-Compliant</span>
+                    <x-filament::icon icon="heroicon-o-shield-exclamation" class="h-4 w-4 text-red-400" />
+                </div>
+                <div class="mt-2 text-4xl font-bold text-red-400">{{ number_format($nonCompliant) }}</div>
+                <div class="mt-1 text-xs text-gray-400">{{ $totalNonPct }}%</div>
+            </div>
+        </a>
+    </div>
+
+    {{-- ============================================================ --}}
+    {{-- Middle row: License Compliance (8 cols) + Rule Category (4)   --}}
+    {{-- ============================================================ --}}
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-4 mt-2">
+        {{-- License Compliance table --}}
+        <div class="lg:col-span-8 rounded-xl bg-[#0c1f3d] border border-amber-400/15 overflow-hidden">
+            <div class="px-5 py-4 flex items-center justify-between border-b border-amber-400/10">
+                <div>
+                    <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">License Compliance</h3>
+                    <p class="text-xs text-gray-400 mt-0.5">Real-time compliance status for all licensed operations</p>
+                </div>
+                <a href="{{ $licenseIndex }}" class="text-xs font-semibold text-amber-400 hover:text-amber-300 flex items-center gap-1">
+                    View all licenses
+                    <x-filament::icon icon="heroicon-o-arrow-right" class="h-3 w-3" />
+                </a>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-[#050d1f]">
+                        <tr class="text-amber-400 text-xs uppercase tracking-wide">
+                            <th class="text-left py-2.5 px-5 font-semibold">Call Sign</th>
+                            <th class="text-left py-2.5 px-3 font-semibold">Licensee</th>
+                            <th class="text-left py-2.5 px-3 font-semibold">Service</th>
+                            <th class="text-left py-2.5 px-3 font-semibold">Status</th>
+                            <th class="text-left py-2.5 px-3 font-semibold">Expiration</th>
+                            <th class="text-right py-2.5 px-5 font-semibold">Compliance Score</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($licenses as $license)
+                            @php $sb = $statusBadge($license->status); @endphp
+                            <tr class="border-b border-white/5 hover:bg-amber-400/5 transition">
+                                <td class="py-3 px-5">
+                                    <a href="{{ \App\Filament\Resources\FccLicenseResource::getUrl('view', ['record' => $license]) }}"
+                                       class="font-semibold text-gray-100 hover:text-amber-300">
+                                        {{ $license->call_sign }}
+                                    </a>
+                                </td>
+                                <td class="py-3 px-3 text-gray-300">{{ \Illuminate\Support\Str::limit($license->licensee, 28) }}</td>
+                                <td class="py-3 px-3"><span class="{{ $serviceBadge($license->service) }}">{{ $license->service }}</span></td>
+                                <td class="py-3 px-3">
+                                    <span class="inline-flex items-center gap-1.5 {{ $sb['text'] }} text-xs font-medium">
+                                        <span class="h-1.5 w-1.5 rounded-full {{ $sb['dot'] }}"></span>
+                                        {{ $sb['label'] }}
+                                    </span>
+                                </td>
+                                <td class="py-3 px-3 text-gray-300">{{ optional($license->expiration_date)->format('M d, Y') }}</td>
+                                <td class="py-3 px-5">
+                                    <div class="flex items-center justify-end gap-2">
+                                        <div class="w-24 h-1.5 bg-[#050d1f] rounded-full overflow-hidden">
+                                            <div class="h-full {{ $barColor($license->compliance_score) }}" style="width: {{ min(100, $license->compliance_score) }}%"></div>
+                                        </div>
+                                        <span class="font-semibold {{ $scoreColor($license->compliance_score) }}">{{ number_format($license->compliance_score, 1) }}%</span>
+                                    </div>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            <div class="px-5 py-3 text-xs text-gray-500 flex items-center justify-between border-t border-amber-400/10">
+                <span>Showing 1 to {{ $licenses->count() }} of {{ $licenses->count() }} licenses</span>
+                <a href="{{ $licenseIndex }}" class="text-amber-400 hover:text-amber-300">Open Licenses →</a>
+            </div>
+        </div>
+
+        {{-- Compliance by Rule Category --}}
+        <div class="lg:col-span-4 rounded-xl bg-[#0c1f3d] border border-amber-400/15 overflow-hidden">
+            <div class="px-5 py-4 flex items-center justify-between border-b border-amber-400/10">
+                <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">Compliance by Rule Category</h3>
+                <a href="{{ $rulesIndex }}" class="text-xs font-semibold text-amber-400 hover:text-amber-300 flex items-center gap-1">
+                    View full report
+                    <x-filament::icon icon="heroicon-o-arrow-right" class="h-3 w-3" />
+                </a>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-[#050d1f]">
+                        <tr class="text-amber-400 text-[10px] uppercase tracking-wide">
+                            <th class="text-left py-2 px-4 font-semibold">Category</th>
+                            <th class="text-right py-2 px-2 font-semibold">Compliant</th>
+                            <th class="text-right py-2 px-2 font-semibold">At Risk</th>
+                            <th class="text-right py-2 px-2 font-semibold">Non-Comp.</th>
+                            <th class="text-right py-2 px-4 font-semibold">%</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($categoryRows as $row)
+                            <tr class="border-b border-white/5 hover:bg-amber-400/5">
+                                <td class="py-2.5 px-4 text-gray-200">{{ $row['label'] }}</td>
+                                <td class="py-2.5 px-2 text-right text-emerald-400 font-semibold">{{ number_format($row['compliant']) }}</td>
+                                <td class="py-2.5 px-2 text-right text-amber-300 font-semibold">{{ number_format($row['at_risk']) }}</td>
+                                <td class="py-2.5 px-2 text-right text-red-400 font-semibold">{{ number_format($row['non_compliant']) }}</td>
+                                <td class="py-2.5 px-4 text-right text-gray-200">{{ $row['percent'] }}%</td>
+                            </tr>
+                        @endforeach
+                        <tr class="border-t border-amber-400/30 bg-[#050d1f]/40">
+                            <td class="py-3 px-4 text-amber-400 font-bold uppercase text-xs">Total</td>
+                            <td class="py-3 px-2 text-right text-emerald-400 font-bold">{{ number_format($compliant) }}</td>
+                            <td class="py-3 px-2 text-right text-amber-300 font-bold">{{ number_format($atRisk) }}</td>
+                            <td class="py-3 px-2 text-right text-red-400 font-bold">{{ number_format($nonCompliant) }}</td>
+                            <td class="py-3 px-4 text-right text-amber-300 font-bold">{{ $overallPct }}%</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    {{-- ============================================================ --}}
+    {{-- Bottom row: Donut + Top Non-Compliant + Deadlines + Activity --}}
+    {{-- ============================================================ --}}
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-4 mt-2">
+
+        {{-- Rule Compliance Overview (donut + breakdown) --}}
+        <div class="lg:col-span-4 rounded-xl bg-[#0c1f3d] border border-amber-400/15 p-5">
+            <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">Rule Compliance Overview</h3>
+            <p class="text-xs text-gray-400 mt-0.5 mb-4">Breakdown of compliance status across all FCC rules</p>
+
+            @php
+                $deg1 = ($compliant / $totalRules) * 360;
+                $deg2 = $deg1 + ($atRisk / $totalRules) * 360;
+            @endphp
+            <div class="flex items-center gap-6">
+                <div class="relative w-36 h-36 shrink-0">
+                    <div class="absolute inset-0 rounded-full"
+                         style="background: conic-gradient(#fbbf24 0deg, #fbbf24 {{ $deg1 }}deg, #f59e0b {{ $deg1 }}deg, #f59e0b {{ $deg2 }}deg, #ef4444 {{ $deg2 }}deg, #ef4444 360deg);">
+                    </div>
+                    <div class="absolute inset-3 rounded-full bg-[#0c1f3d] flex flex-col items-center justify-center">
+                        <div class="text-2xl font-bold text-amber-400">{{ $overallPct }}%</div>
+                        <div class="text-[10px] uppercase tracking-wide text-gray-400">Compliant</div>
+                    </div>
+                </div>
+                <div class="flex-1 text-sm space-y-2">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-amber-400"></span><span class="text-gray-300">Compliant</span></div>
+                        <div class="text-right"><span class="text-amber-400 font-semibold">{{ $totalCompliantPct }}%</span> <span class="text-gray-500 ml-1">{{ number_format($compliant) }}</span></div>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-amber-500"></span><span class="text-gray-300">At Risk</span></div>
+                        <div class="text-right"><span class="text-amber-300 font-semibold">{{ $totalAtRiskPct }}%</span> <span class="text-gray-500 ml-1">{{ number_format($atRisk) }}</span></div>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2"><span class="h-2 w-2 rounded-full bg-red-400"></span><span class="text-gray-300">Non-Compliant</span></div>
+                        <div class="text-right"><span class="text-red-400 font-semibold">{{ $totalNonPct }}%</span> <span class="text-gray-500 ml-1">{{ number_format($nonCompliant) }}</span></div>
+                    </div>
+                    <div class="border-t border-white/10 pt-2 mt-2 flex items-center justify-between">
+                        <span class="text-gray-400 text-xs uppercase tracking-wide">Total Requirements</span>
+                        <span class="font-semibold text-gray-200">{{ number_format($totalRules) }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Top Non-Compliant Rules --}}
+        <div class="lg:col-span-4 rounded-xl bg-[#0c1f3d] border border-amber-400/15 overflow-hidden">
+            <div class="px-5 py-4 flex items-center justify-between border-b border-amber-400/10">
+                <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">Top Non-Compliant Rules</h3>
+                <a href="{{ $rulesIndex }}" class="text-xs font-semibold text-amber-400 hover:text-amber-300">View all →</a>
+            </div>
+            <table class="w-full text-sm">
+                <thead class="bg-[#050d1f]">
+                    <tr class="text-amber-400 text-[10px] uppercase tracking-wide">
+                        <th class="text-left py-2 px-5 font-semibold">FCC Rule</th>
+                        <th class="text-left py-2 px-2 font-semibold">Description</th>
+                        <th class="text-right py-2 px-2 font-semibold">Affected</th>
+                        <th class="text-right py-2 px-5 font-semibold">Severity</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($topNonCompliant as $rule)
+                        @php
+                            $sevColor = match ($rule->severity) {
+                                'critical' => 'text-red-400 bg-red-400/10 border-red-400/30',
+                                'high'     => 'text-amber-300 bg-amber-400/10 border-amber-400/30',
+                                'medium'   => 'text-sky-300 bg-sky-400/10 border-sky-400/30',
+                                default    => 'text-gray-400 bg-gray-400/10 border-gray-400/30',
+                            };
+                        @endphp
+                        <tr class="border-b border-white/5 hover:bg-amber-400/5">
+                            <td class="py-2.5 px-5 font-semibold text-amber-300">{{ $rule->rule_number }}</td>
+                            <td class="py-2.5 px-2 text-gray-300">{{ \Illuminate\Support\Str::limit($rule->title, 32) }}</td>
+                            <td class="py-2.5 px-2 text-right font-semibold text-gray-200">{{ $rule->affected_count }}</td>
+                            <td class="py-2.5 px-5 text-right">
+                                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold border {{ $sevColor }}">
+                                    {{ ucfirst($rule->severity) }}
+                                </span>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+
+        {{-- Upcoming FCC Deadlines + Compliance Activity stacked --}}
+        <div class="lg:col-span-4 space-y-4">
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/15 overflow-hidden">
+                <div class="px-5 py-4 flex items-center justify-between border-b border-amber-400/10">
+                    <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">Upcoming FCC Deadlines</h3>
+                    <a href="{{ $deadlinesIndex }}" class="text-xs font-semibold text-amber-400 hover:text-amber-300">View all →</a>
+                </div>
+                <ul class="divide-y divide-white/5">
+                    @foreach ($deadlines as $d)
+                        @php
+                            $days = max(0, (int) now()->startOfDay()->diffInDays($d->due_date->startOfDay(), false));
+                            $urgent = $days <= 14;
+                        @endphp
+                        <li class="px-5 py-2.5 flex items-center gap-3 text-sm hover:bg-amber-400/5">
+                            <x-filament::icon icon="heroicon-o-calendar-days" class="h-4 w-4 text-amber-400 shrink-0" />
+                            <div class="text-amber-300 font-semibold w-24 shrink-0 text-xs uppercase">{{ $d->due_date->format('M d, Y') }}</div>
+                            <div class="flex-1 text-gray-200 truncate">{{ $d->title }}</div>
+                            <div class="text-xs {{ $urgent ? 'text-red-400 font-semibold' : 'text-gray-400' }} shrink-0">{{ $days }} days</div>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+
+            <div class="rounded-xl bg-[#0c1f3d] border border-amber-400/15 overflow-hidden">
+                <div class="px-5 py-4 flex items-center justify-between border-b border-amber-400/10">
+                    <h3 class="text-base font-semibold text-gray-100 uppercase tracking-wide">Compliance Activity</h3>
+                    <span class="text-xs text-gray-500">audit trail</span>
+                </div>
+                <ul class="divide-y divide-white/5">
+                    @foreach ($activity as $event)
+                        @php
+                            $iconMap = [
+                                'technical_review_passed' => ['icon' => 'heroicon-o-check-circle',     'color' => 'text-emerald-400'],
+                                'eas_test_filed'          => ['icon' => 'heroicon-o-shield-check',     'color' => 'text-emerald-400'],
+                                'public_file_uploaded'    => ['icon' => 'heroicon-o-document-arrow-up', 'color' => 'text-sky-300'],
+                                'report_generated'        => ['icon' => 'heroicon-o-document-text',    'color' => 'text-sky-300'],
+                                'power_warning'           => ['icon' => 'heroicon-o-exclamation-triangle', 'color' => 'text-amber-300'],
+                            ];
+                            $cfg = $iconMap[$event->event_type] ?? ['icon' => 'heroicon-o-information-circle', 'color' => 'text-gray-400'];
+                        @endphp
+                        <li class="px-5 py-2.5 flex items-start gap-3 text-sm hover:bg-amber-400/5">
+                            <x-filament::icon :icon="$cfg['icon']" class="h-4 w-4 {{ $cfg['color'] }} shrink-0 mt-0.5" />
+                            <div class="flex-1 min-w-0">
+                                <div class="text-gray-200 truncate">{{ $event->summary }}</div>
+                                <div class="text-xs text-gray-500 mt-0.5">{{ $event->actor }} · {{ optional($event->occurred_at)->diffForHumans() }}</div>
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/fcc-dashboard.blade.php
+++ b/resources/views/filament/pages/fcc-dashboard.blade.php
@@ -166,7 +166,7 @@
                 </table>
             </div>
             <div class="px-5 py-3 text-xs text-gray-500 flex items-center justify-between border-t border-amber-400/10">
-                <span>Showing 1 to {{ $licenses->count() }} of {{ $licenses->count() }} licenses</span>
+                <span>Showing 1 to {{ $licenses->count() }} of {{ number_format($totalLicenses) }} licenses</span>
                 <a href="{{ $licenseIndex }}" class="text-amber-400 hover:text-amber-300">Open Licenses →</a>
             </div>
         </div>

--- a/resources/views/filament/topbar/fcc-alerts-badge.blade.php
+++ b/resources/views/filament/topbar/fcc-alerts-badge.blade.php
@@ -1,0 +1,30 @@
+@php
+    use App\Models\FccDeadline;
+    use App\Models\FccLicense;
+    use App\Models\FccRegulatoryFee;
+
+    $overdueDeadlines = FccDeadline::query()
+        ->where('status', '!=', 'completed')
+        ->where('due_date', '<', now()->addDays(14))
+        ->count();
+
+    $nonCompliantLicenses = FccLicense::query()
+        ->whereIn('status', ['non_compliant'])
+        ->count();
+
+    $overdueFees = class_exists(FccRegulatoryFee::class)
+        ? FccRegulatoryFee::query()->where('status', 'overdue')->count()
+        : 0;
+
+    $alertCount = $overdueDeadlines + $nonCompliantLicenses + $overdueFees;
+    $deadlinesUrl = \App\Filament\Resources\FccDeadlineResource::getUrl('index');
+@endphp
+
+@if ($alertCount > 0)
+    <a href="{{ $deadlinesUrl }}"
+       class="fi-fcc-alerts-badge {{ $nonCompliantLicenses > 0 ? 'is-critical' : '' }}"
+       title="{{ $nonCompliantLicenses }} non-compliant licenses, {{ $overdueDeadlines }} urgent deadlines, {{ $overdueFees }} overdue fees">
+        <x-filament::icon icon="heroicon-o-bell-alert" class="h-4 w-4" />
+        {{ $alertCount }} Alert{{ $alertCount === 1 ? '' : 's' }}
+    </a>
+@endif

--- a/resources/views/filament/topbar/fcc-export-button.blade.php
+++ b/resources/views/filament/topbar/fcc-export-button.blade.php
@@ -1,0 +1,6 @@
+<a href="{{ route('fcc.report.csv') }}"
+   class="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-amber-400 hover:bg-amber-300 text-[#0a1830] text-xs font-semibold transition shadow-sm"
+   title="Download a CSV summary of all FCC compliance data">
+    <x-filament::icon icon="heroicon-o-arrow-down-tray" class="h-4 w-4" />
+    Export FCC Report
+</a>

--- a/resources/views/filament/widgets/fcc-rule-category-rollup.blade.php
+++ b/resources/views/filament/widgets/fcc-rule-category-rollup.blade.php
@@ -1,0 +1,30 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        <x-slot name="heading">Compliance by Rule Category</x-slot>
+
+        <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b border-amber-400/20 text-amber-400 uppercase text-xs tracking-wide">
+                        <th class="text-left py-2 px-2">Category</th>
+                        <th class="text-right py-2 px-2">Compliant</th>
+                        <th class="text-right py-2 px-2">At Risk</th>
+                        <th class="text-right py-2 px-2">Non-Compliant</th>
+                        <th class="text-right py-2 px-2">Compliance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($this->getCategoryRows() as $row)
+                        <tr class="@if(!empty($row['is_total'])) border-t border-amber-400/30 font-semibold text-amber-300 @else border-b border-white/5 @endif">
+                            <td class="py-2 px-2">{{ $row['category'] }}</td>
+                            <td class="py-2 px-2 text-right text-emerald-400">{{ number_format($row['compliant']) }}</td>
+                            <td class="py-2 px-2 text-right text-amber-400">{{ number_format($row['at_risk']) }}</td>
+                            <td class="py-2 px-2 text-right text-red-400">{{ number_format($row['non_compliant']) }}</td>
+                            <td class="py-2 px-2 text-right">{{ $row['percent'] }}%</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,13 @@ Route::get('login', function () {
     return redirect()->route('filament.app.auth.login');
 })->name('login');
 
+// FCC Compliance — full report CSV download (auth required via Filament panel)
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::get('/app/fcc-report.csv',
+        [\App\Http\Controllers\FccComplianceReportController::class, 'csv']
+    )->name('fcc.report.csv');
+});
+
 Route::middleware(['auth'])->group(function () {
 
     Route::get('/app/reset-password', PasswordResetPage::class)->name('password-reset-page');


### PR DESCRIPTION
Visual reskin to a deep-navy + gold theme matching the FCC Compliance dashboard, plus first-class FCC broadcast entities so the product is usable end-to-end by an FCC compliance officer at a radio/TV station.

Theme:
- New navy & gold palette in resources/css/filament/app/theme.css (legacy `grcblue` token names retained, now resolve to navy ramp; new `grcgold` ramp for amber accents)
- Sidebar, topbar, active states, scrollbar, primary buttons, stat widgets restyled to match the dashboard mock
- Brand names updated to "OpenGRC FCC Compliance" / "...Admin"
- All 4 panel providers (Admin/App/TrustCenter/Vendor) recolored to the navy + gold scheme

Domain model (new):
- fcc_facilities          (FCC Facility ID, ASR #, HAAT/AMSL, owner...)
- fcc_licenses            (call sign, FRN, licensee, service, freq/ch,
                          grant/expiration/renewal, status, score)
- fcc_transmitters        (manufacturer/model, ERP, EAS ENDEC, proofs)
- fcc_rules               (47 CFR sections - Parts 73, 11, 17)
- fcc_license_rule_status (per-license rule compliance status)
- fcc_deadlines           (EAS, public file, renewal, ownership,
                          tower lighting, etc.)
- fcc_compliance_events   (audit-trail style activity stream)

Filament UI:
- FccLicenseResource with full broadcast fields and compliance badges
- FccFacilityResource, FccTransmitterResource, FccRuleResource, FccDeadlineResource (lean Manage pages)
- New "FCC Compliance" navigation group
- FccComplianceOverviewWidget — Compliance/Licenses/Rules/Compliant/ At Risk/Non-Compliant stats matching the dashboard top row
- FccUpcomingDeadlinesWidget — quarterly EAS, public file, renewal, Issues/Programs, tower lighting

Demo data (FccComplianceSeeder, wired into DatabaseSeeder):
- 8 stations matching the mock (KXYZ-FM, WABC-AM, WQRS-TV, KLMN-LP, KDEF-FM, KJKL-TV, KPOW-AM, KZ99-FM) with realistic FRNs, services, expiration dates, compliance scores, transmitters
- 18 real CFR sections (73.3526, 73.1212, 73.317, 73.659, 11.35, 11.61, 17.47, etc.) categorized & severity-ranked
- Per-license rule status to drive the "By Category" rollup
- Upcoming deadlines + recent compliance activity