### PR TITLE
Fix ambiguous "id" column when attaching records to a policy

### DIFF
--- a/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/ImplementationResource/RelationManagers/ControlsRelationManager.php
@@ -44,7 +44,7 @@ class ControlsRelationManager extends RelationManager
                     ->label('Relate to Control')
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(function (Builder $query) {
-                        $query->select(['id', 'code', 'title']); // Select only necessary columns
+                        $query->select(['controls.id', 'code', 'title']); // Select only necessary columns
                     })
                     ->recordTitle(function ($record) {
                         // Concatenate code and title for the option label

--- a/app/Filament/Resources/PolicyResource/RelationManagers/ControlsRelationManager.php
+++ b/app/Filament/Resources/PolicyResource/RelationManagers/ControlsRelationManager.php
@@ -53,7 +53,7 @@ class ControlsRelationManager extends RelationManager
                     ->label('Attach Control')
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(function (Builder $query) {
-                        $query->select(['id', 'code', 'title']);
+                        $query->select(['controls.id', 'code', 'title']);
                     })
                     ->recordTitle(function ($record) {
                         return strip_tags("({$record->code}) {$record->title}");

--- a/app/Filament/Resources/PolicyResource/RelationManagers/ImplementationsRelationManager.php
+++ b/app/Filament/Resources/PolicyResource/RelationManagers/ImplementationsRelationManager.php
@@ -58,7 +58,7 @@ class ImplementationsRelationManager extends RelationManager
                     ->label('Attach Implementation')
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(function (Builder $query) {
-                        $query->select(['id', 'title']);
+                        $query->select(['implementations.id', 'title']);
                     })
                     ->recordTitle(function ($record) {
                         return strip_tags($record->title);

--- a/app/Filament/Resources/PolicyResource/RelationManagers/RisksRelationManager.php
+++ b/app/Filament/Resources/PolicyResource/RelationManagers/RisksRelationManager.php
@@ -49,7 +49,7 @@ class RisksRelationManager extends RelationManager
                     ->label('Attach Risk')
                     ->preloadRecordSelect()
                     ->recordSelectOptionsQuery(function (Builder $query) {
-                        $query->select(['id', 'name']);
+                        $query->select(['risks.id', 'name']);
                     })
                     ->recordTitle(function ($record) {
                         return strip_tags($record->name);


### PR DESCRIPTION
## Problem

Attaching a control, risk, or implementation to a Policy throws:

```
SQLSTATE[HY000]: General error: 1 ambiguous column name: id
```

Filament's `AttachAction` adds a `LEFT JOIN` onto the pivot table when building the record-select options query. The affected relation managers selected a bare `id` in `recordSelectOptionsQuery`, which then matches both the base table and the pivot table's `id` column — making the reference ambiguous.

## Fix

Qualify the `id` column with its table name, matching the convention already used by the working relation managers (e.g. `PoliciesRelationManager` and `RiskResource/ImplementationsRelationManager`).

Changed files:
- `PolicyResource/RelationManagers/ControlsRelationManager.php` → `controls.id`
- `PolicyResource/RelationManagers/RisksRelationManager.php` → `risks.id`
- `PolicyResource/RelationManagers/ImplementationsRelationManager.php` → `implementations.id`
- `ImplementationResource/RelationManagers/ControlsRelationManager.php` → `controls.id`

`code`/`title`/`name` exist only on the base table (not the pivot), so only `id` needed qualifying. The fix is identical for SQLite, MySQL strict mode, and Postgres.

Fixes #271