### PR TITLE
Link risks to assets

### DIFF
--- a/app/Filament/Resources/AssetResource.php
+++ b/app/Filament/Resources/AssetResource.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\AssetResource\Pages\EditAsset;
 use App\Filament\Resources\AssetResource\Pages\ListAssets;
 use App\Filament\Resources\AssetResource\Pages\ViewAsset;
 use App\Filament\Resources\AssetResource\RelationManagers\ImplementationsRelationManager;
+use App\Filament\Resources\AssetResource\RelationManagers\RisksRelationManager;
 use App\Models\Asset;
 use App\Models\User;
 use Filament\Actions\BulkActionGroup;
@@ -1503,6 +1504,7 @@ class AssetResource extends Resource
     {
         return [
             ImplementationsRelationManager::class,
+            RisksRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/AssetResource/RelationManagers/RisksRelationManager.php
+++ b/app/Filament/Resources/AssetResource/RelationManagers/RisksRelationManager.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Filament\Resources\AssetResource\RelationManagers;
+
+use Filament\Actions\AttachAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DetachAction;
+use Filament\Actions\DetachBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class RisksRelationManager extends RelationManager
+{
+    protected static string $relationship = 'risks';
+
+    protected static ?string $title = 'Risks';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('name')
+            ->columns([
+                TextColumn::make('code')
+                    ->sortable()
+                    ->searchable()
+                    ->badge()
+                    ->color('primary')
+                    ->wrap(),
+
+                TextColumn::make('name')
+                    ->sortable()
+                    ->searchable()
+                    ->limit(50)
+                    ->wrap(),
+
+                TextColumn::make('residual_risk')
+                    ->label('Residual Risk')
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                AttachAction::make()
+                    ->label('Relate to Risk')
+                    ->preloadRecordSelect()
+                    ->recordSelectOptionsQuery(function (Builder $query) {
+                        $query->select(['risks.id', 'risks.code', 'risks.name']);
+                    })
+                    ->recordTitle(function ($record) {
+                        return strip_tags("({$record->code}) {$record->name}");
+                    })
+                    ->recordSelectSearchColumns(['code', 'name']),
+            ])
+            ->recordActions([
+                ViewAction::make()
+                    ->url(fn ($record) => route('filament.app.resources.risks.view', $record)),
+                DetachAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DetachBulkAction::make()->label('Detach from Asset'),
+                ]),
+            ]);
+    }
+
+    public function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Resources/RiskResource.php
+++ b/app/Filament/Resources/RiskResource.php
@@ -13,6 +13,7 @@ use App\Filament\Resources\RiskResource\Pages\CreateRisk;
 use App\Filament\Resources\RiskResource\Pages\ListRiskActivities;
 use App\Filament\Resources\RiskResource\Pages\ListRisks;
 use App\Filament\Resources\RiskResource\Pages\ViewRisk;
+use App\Filament\Resources\RiskResource\RelationManagers\AssetsRelationManager;
 use App\Filament\Resources\RiskResource\RelationManagers\ImplementationsRelationManager;
 use App\Filament\Resources\RiskResource\RelationManagers\MitigationsRelationManager;
 use App\Filament\Resources\RiskResource\RelationManagers\PoliciesRelationManager;
@@ -232,6 +233,7 @@ class RiskResource extends Resource
         return [
             'implementations' => ImplementationsRelationManager::class,
             'policies' => PoliciesRelationManager::class,
+            'assets' => AssetsRelationManager::class,
             'mitigations' => MitigationsRelationManager::class,
         ];
     }

--- a/app/Filament/Resources/RiskResource/Pages/CreateRisk.php
+++ b/app/Filament/Resources/RiskResource/Pages/CreateRisk.php
@@ -262,6 +262,26 @@ class CreateRisk extends CreateRecord
 
                         ]),
 
+                    Section::make('Related Assets')
+                        ->columnSpan(2)
+                        ->schema([
+                            Placeholder::make('assets')
+                                ->hiddenLabel(true)
+                                ->columnSpanFull()
+                                ->content('If this risk relates to specific assets in OpenGRC,
+                                you can link them here. You can relate these later if you need to.'),
+                            Select::make('assets')
+                                ->label('Related Assets')
+                                ->helperText('Which assets does this risk apply to?')
+                                ->relationship('assets', 'name')
+                                ->getOptionLabelFromRecordUsing(fn ($record) => $record->asset_tag
+                                    ? "({$record->asset_tag}) {$record->name}"
+                                    : $record->name)
+                                ->searchable(['name', 'asset_tag'])
+                                ->multiple(),
+
+                        ]),
+
                 ]),
 
         ];

--- a/app/Filament/Resources/RiskResource/RelationManagers/AssetsRelationManager.php
+++ b/app/Filament/Resources/RiskResource/RelationManagers/AssetsRelationManager.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources\RiskResource\RelationManagers;
+
+use Filament\Actions\AttachAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DetachAction;
+use Filament\Actions\DetachBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class AssetsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'assets';
+
+    protected static ?string $title = 'Assets';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with(['assetType', 'status']))
+            ->recordTitleAttribute('name')
+            ->columns([
+                TextColumn::make('asset_tag')
+                    ->label('Asset Tag')
+                    ->sortable()
+                    ->searchable()
+                    ->badge()
+                    ->color('primary')
+                    ->wrap(),
+
+                TextColumn::make('name')
+                    ->sortable()
+                    ->searchable()
+                    ->limit(50)
+                    ->wrap(),
+
+                TextColumn::make('assetType.name')
+                    ->label('Type')
+                    ->sortable(),
+
+                TextColumn::make('status.name')
+                    ->label('Status')
+                    ->badge()
+                    ->sortable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                AttachAction::make()
+                    ->label('Relate to Asset')
+                    ->preloadRecordSelect()
+                    ->recordSelectOptionsQuery(function (Builder $query) {
+                        $query->select(['assets.id', 'assets.asset_tag', 'assets.name']);
+                    })
+                    ->recordTitle(function ($record) {
+                        return $record->asset_tag
+                            ? strip_tags("({$record->asset_tag}) {$record->name}")
+                            : strip_tags($record->name);
+                    })
+                    ->recordSelectSearchColumns(['asset_tag', 'name']),
+            ])
+            ->recordActions([
+                ViewAction::make()
+                    ->url(fn ($record) => route('filament.app.resources.assets.view', $record)),
+                DetachAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DetachBulkAction::make()->label('Detach from Risk'),
+                ]),
+            ]);
+    }
+
+    public function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Models/Asset.php
+++ b/app/Models/Asset.php
@@ -341,6 +341,15 @@ class Asset extends Model
     }
 
     /**
+     * Get the risks associated with this asset.
+     */
+    public function risks(): BelongsToMany
+    {
+        return $this->belongsToMany(Risk::class)
+            ->withTimestamps();
+    }
+
+    /**
      * Get the asset type name accessor.
      */
     public function getAssetTypeNameAttribute(): ?string

--- a/app/Models/Risk.php
+++ b/app/Models/Risk.php
@@ -10,8 +10,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 class Risk extends Model
 {
@@ -52,6 +52,12 @@ class Risk extends Model
     public function programs(): BelongsToMany
     {
         return $this->belongsToMany(Program::class);
+    }
+
+    public function assets(): BelongsToMany
+    {
+        return $this->belongsToMany(Asset::class)
+            ->withTimestamps();
     }
 
     public function mitigations(): MorphMany

--- a/database/migrations/2026_06_02_000000_create_asset_risk_table.php
+++ b/database/migrations/2026_06_02_000000_create_asset_risk_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('asset_risk', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('asset_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('risk_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['asset_id', 'risk_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('asset_risk');
+    }
+};


### PR DESCRIPTION
## Summary

Implements the enhancement request to link the risk management module to assets, enabling the workflow of identifying business-critical assets and then enumerating the risks related to each (e.g. *building01* → fire, flood, lost keys; *SaaS service* → DDoS, account compromise).

Adds a bidirectional many-to-many relationship between assets and risks, manageable from both sides of the UI.

## Changes

- **Migration** — new `asset_risk` pivot table (`asset_id`, `risk_id`, timestamps, unique constraint, cascade-on-delete).
- **Models** — `Risk::assets()` and `Asset::risks()` `belongsToMany` relationships.
- **Risk resource** — `AssetsRelationManager` to attach/detach assets to a risk (search by asset tag/name, links through to the asset view).
- **Asset resource** — `RisksRelationManager` to attach/detach risks to an asset (search by code/name, links through to the risk view).

## Notes

- The attach record-select queries qualify the `id` column with the table name (`assets.id` / `risks.id`) so they don't hit the ambiguous-column error under MySQL strict mode (same class of issue as #271).
- Relation managers mirror the existing `PoliciesRelationManager`/`ImplementationsRelationManager` conventions; create is disabled (attach existing records only).

## Testing

- Migration runs cleanly.
- Verified both relationships resolve to the shared `asset_risk` pivot, and an attach/detach round-trip persists the pivot row (with timestamps) and is visible from both `risk->assets` and `asset->risks`.

Closes #269